### PR TITLE
ensure default TTL and priority are applied if none provided

### DIFF
--- a/mappers.go
+++ b/mappers.go
@@ -6,6 +6,12 @@ import (
 	"github.com/libdns/libdns"
 )
 
+// Default priority applied by infomaniak
+const defaultPriority = 10
+
+// Default TTL that is applied if none is provided - infomaniak requires a TTL
+const defaultTtlSecs = 300
+
 // ToLibDnsRecord maps a infomaniak dns record to a libdns record
 func (ikr *IkRecord) ToLibDnsRecord(zone string) libdns.Record {
 	return libdns.Record{
@@ -25,10 +31,17 @@ func ToInfomaniakRecord(libdnsRec *libdns.Record, zone string) IkRecord {
 		Type:      libdnsRec.Type,
 		SourceIdn: libdns.AbsoluteName(libdnsRec.Name, zone),
 		Target:    libdnsRec.Value,
+		TtlInSec:  uint(libdnsRec.TTL),
 		Priority:  uint(libdnsRec.Priority),
 	}
-	if libdnsRec.TTL != 0 {
-		ikRec.TtlInSec = uint(libdnsRec.TTL)
+
+	if ikRec.TtlInSec <= 0 {
+		ikRec.TtlInSec = defaultTtlSecs
 	}
+
+	if ikRec.Priority <= 0 {
+		ikRec.Priority = defaultPriority
+	}
+
 	return ikRec
 }

--- a/mappers_test.go
+++ b/mappers_test.go
@@ -1,0 +1,70 @@
+package infomaniak
+
+import (
+	"testing"
+
+	"github.com/libdns/libdns"
+)
+
+func Test_ToLibDnsRecord_MapsAllProperties(t *testing.T) {
+	ikRec := IkRecord{
+		ID:       "123456",
+		Type:     "MX",
+		Target:   "127.0.0.1",
+		TtlInSec: 3600,
+		Priority: 17,
+	}
+
+	libRec := ikRec.ToLibDnsRecord("")
+	assertEquals(t, "ID", ikRec.ID, libRec.ID)
+	assertEquals(t, "Type", ikRec.Type, libRec.Type)
+	assertEquals(t, "Value", ikRec.Target, libRec.Value)
+	assertEqualsInt(t, "TTL", int(ikRec.TtlInSec), int(int64(libRec.TTL)))
+	assertEqualsInt(t, "Priority", int(ikRec.Priority), libRec.Priority)
+}
+
+func Test_ToLibDnsRecord_ReturnsRelativeName(t *testing.T) {
+	subzone := "sub"
+	zone := "example.com"
+
+	ikRec := IkRecord{
+		SourceIdn: subzone + "." + zone,
+	}
+
+	libRec := ikRec.ToLibDnsRecord(zone)
+	assertEquals(t, "Name", subzone, libRec.Name)
+}
+
+func Test_ToInfomaniakRecord_MapsAllProperties(t *testing.T) {
+	libRec := libdns.Record{
+		ID:       "123456",
+		Type:     "MX",
+		Value:    "127.0.0.1",
+		TTL:      3600,
+		Priority: 17,
+	}
+
+	ikRec := ToInfomaniakRecord(&libRec, "")
+	assertEquals(t, "ID", libRec.ID, ikRec.ID)
+	assertEquals(t, "Type", libRec.Type, ikRec.Type)
+	assertEquals(t, "Value", libRec.Value, ikRec.Target)
+	assertEqualsInt(t, "TTL", int(libRec.TTL), int(ikRec.TtlInSec))
+	assertEqualsInt(t, "Priority", libRec.Priority, int(ikRec.Priority))
+}
+
+func Test_ToInfomaniakRecord_DefaultTtlIsAppliedIfNoTtlProvided(t *testing.T) {
+	ikRec := ToInfomaniakRecord(&libdns.Record{}, "")
+	assertEqualsInt(t, "TTL", defaultTtlSecs, int(ikRec.TtlInSec))
+}
+
+func Test_ToInfomaniakRecord_DefaultPriorityIsAppliedIfPriority(t *testing.T) {
+	ikRec := ToInfomaniakRecord(&libdns.Record{}, "")
+	assertEqualsInt(t, "Priority", defaultPriority, int(ikRec.Priority))
+}
+
+func Test_ToInfomaniakRecord_SetsAbsoluteNameToSource(t *testing.T) {
+	subzone := "sub"
+	zone := "example.com"
+	ikRec := ToInfomaniakRecord(&libdns.Record{Name: subzone}, zone)
+	assertEquals(t, "SourceIdn", subzone+"."+zone, ikRec.SourceIdn)
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -37,6 +37,16 @@ func assertEquals(t *testing.T, name string, expected string, actual string) {
 	}
 }
 
+// assertEqualsInt helper function that throws an error if the actual int value is not the expected value
+func assertEqualsInt(t *testing.T, name string, expected int, actual int) {
+	assertEquals(t, name, convertIntToString(expected), convertIntToString(actual))
+}
+
+// convertIntToString converts an int value to a string
+func convertIntToString(number int) string {
+	return strconv.FormatInt(int64(number), 10)
+}
+
 func Test_GetRecords_ReturnsRecords(t *testing.T) {
 	subDomain := "subdomain"
 	expectedRec := IkRecord{ID: "1893", Type: "AAAA", SourceIdn: subDomain + ".example.com", Target: "ns11.infomaniak.ch", TtlInSec: 301, Priority: 15}
@@ -51,10 +61,10 @@ func Test_GetRecords_ReturnsRecords(t *testing.T) {
 	actualRec := result[0]
 	assertEquals(t, "ID", expectedRec.ID, actualRec.ID)
 	assertEquals(t, "Name", subDomain, actualRec.Name)
-	assertEquals(t, "TTL", strconv.FormatInt(int64(expectedRec.TtlInSec), 10), strconv.FormatInt(int64(actualRec.TTL), 10))
+	assertEqualsInt(t, "TTL", int(expectedRec.TtlInSec), int(actualRec.TTL))
 	assertEquals(t, "Type", expectedRec.Type, actualRec.Type)
 	assertEquals(t, "Value", expectedRec.Target, actualRec.Value)
-	assertEquals(t, "Priority", strconv.FormatInt(int64(expectedRec.Priority), 10), strconv.FormatInt(int64(actualRec.Priority), 10))
+	assertEqualsInt(t, "Priority", int(expectedRec.Priority), actualRec.Priority)
 }
 
 func Test_AppendRecords_DoesNotAppendRecordWithId(t *testing.T) {

--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -208,6 +208,21 @@ func Test_SetRecords_UpdatesRecordById(t *testing.T) {
 	assertExists(t, updatedRec)
 }
 
+func Test_SetRecords_WorksWithoutTtl(t *testing.T) {
+	defer cleanup()
+
+	rec := aTestRecord(zone, "127.0.0.1")
+	rec.Type = "TXT"
+	rec.TTL = 0
+
+	result := setRecord(t, rec)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 record updated, got %d", len(result))
+	}
+	assertExists(t, rec)
+}
+
 func Test_SetRecords_OverwritesExistingRecordWithSameNameAndType(t *testing.T) {
 	defer cleanup()
 


### PR DESCRIPTION
Infomaniak fails if no TTL is provided. Therefore a default TTL is applied if none is provided.

Infomaniak's default priority is 10. Make sure this default priority is applied in case none is provided.

This PR fixes #1 