### PR TITLE
Fix zone with trailing dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ infomaniak for [`libdns`](https://github.com/libdns/libdns)
 
 [![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/infomaniak)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [infomaniak](https://infomaniak), allowing you to manage DNS records.
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [infomaniak](https://infomaniak.com), allowing you to manage DNS records.
 
 ## Code example
 ```go

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/libdns/libdns"
@@ -54,7 +55,7 @@ func (c *Client) GetDnsRecordsForZone(ctx context.Context, zone string) ([]IkRec
 
 	zoneRecords := make([]IkRecord, 0)
 	for _, rec := range dnsRecords {
-		if bytes.Contains([]byte(rec.SourceIdn), []byte(zone)) {
+		if strings.HasSuffix(rec.SourceIdn, zone) {
 			zoneRecords = append(zoneRecords, rec)
 		}
 	}
@@ -133,7 +134,7 @@ func (c *Client) getDomainForZone(ctx context.Context, zone string) (IkDomain, e
 		c.domains = &domains
 	}
 	for _, domain := range *c.domains {
-		if bytes.Contains([]byte(zone), []byte(domain.Name)) {
+		if strings.HasSuffix(zone, domain.Name) {
 			return domain, nil
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *Client) getDomainForZone(ctx context.Context, zone string) (IkDomain, e
 			return domain, nil
 		}
 	}
-	return IkDomain{}, fmt.Errorf("Could not find a domain name for zone %s in listed services", zone)
+	return IkDomain{}, fmt.Errorf("could not find a domain name for zone %s in listed services", zone)
 }
 
 // doRequest performs the API call for the given request req and parses the response's data to the given data struct - if the parameter is not nil

--- a/provider.go
+++ b/provider.go
@@ -159,10 +159,10 @@ func (p *Provider) mergeRecordsWithExistingOnes(ctx context.Context, zone string
 	result := make([]libdns.Record, 0)
 	for _, rec := range records {
 		if rec.ID != "" {
-			return nil, errors.New("Got record that already exists as parameter")
+			return nil, errors.New("got record that already exists as parameter")
 		}
 		recordsWithSameCoords := existingRecords[getCoordinates(rec)]
-		if recordsWithSameCoords != nil && len(recordsWithSameCoords) > 0 {
+		if len(recordsWithSameCoords) > 0 {
 			for _, existingRec := range recordsWithSameCoords {
 				copy := rec
 				copy.ID = existingRec.ID

--- a/provider_test.go
+++ b/provider_test.go
@@ -52,7 +52,7 @@ func Test_GetRecords_ReturnsRecords(t *testing.T) {
 	expectedRec := IkRecord{ID: "1893", Type: "AAAA", SourceIdn: subDomain + ".example.com", Target: "ns11.infomaniak.ch", TtlInSec: 301, Priority: 15}
 	client := TestClient{getter: func(ctx context.Context, zone string) ([]IkRecord, error) { return []IkRecord{expectedRec}, nil }}
 	provider := Provider{client: &client}
-	result, _ := provider.GetRecords(nil, "example.com")
+	result, _ := provider.GetRecords(context.TODO(), "example.com")
 
 	if len(result) != 1 {
 		t.Fatalf("Expected %d records, got %d", 1, len(result))
@@ -75,7 +75,7 @@ func Test_AppendRecords_DoesNotAppendRecordWithId(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(nil, "", []libdns.Record{{ID: "1893"}})
+	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{ID: "1893"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func Test_AppendRecords_AppendsNotExistingRecord(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(nil, "", []libdns.Record{{}})
+	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func Test_AppendRecords_DoesNotAppendAlreadyExistingRecord(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(nil, "", []libdns.Record{{ID: "222", Type: recType, Name: name}})
+	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{ID: "222", Type: recType, Name: name}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func Test_SetRecords_CreatesNewRecord(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(nil, "", []libdns.Record{{}})
+	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func Test_SetRecords_UpdatesExistingRecordById(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(nil, "", []libdns.Record{{ID: id}})
+	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{ID: id}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func Test_SetRecords_UpdatesExistingRecordByNameAndTypeIfNoIdProvided(t *testing
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(nil, "", []libdns.Record{{Type: recType}})
+	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{Type: recType}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func Test_DeleteRecords_DoesNotDeleteRecordWithoutIdWhoseNameAndTypeDoesNotMatch
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(nil, "", []libdns.Record{{}})
+	deletedRecs, err := provider.DeleteRecords(context.TODO(), "", []libdns.Record{{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func Test_Delete_Records_DeletesRecordWithSameNameAndTypeIfGivenRecordHasNoId(t 
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(nil, "example.com", []libdns.Record{{Type: recType, Name: subDomain}})
+	deletedRecs, err := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{{Type: recType, Name: subDomain}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func Test_DeleteRecords_DeletesRecordWithId(t *testing.T) {
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(nil, "", []libdns.Record{rec})
+	deletedRecs, err := provider.DeleteRecords(context.TODO(), "", []libdns.Record{rec})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes #3 
- Remove all go warnings
- Ensure that provider works correctly if provided zone has a trailing dot