### PR TITLE
Upgrade to libdns v1.0.0-beta and infomaniak API v2

### DIFF
--- a/.devcontainer/.caddyfile
+++ b/.devcontainer/.caddyfile
@@ -1,0 +1,13 @@
+{
+    log default {
+        format console
+    }
+    email <your_test_email_here>
+    acme_dns infomaniak <your_test_token_here>
+    http_port 8080
+    https_port 8081
+}
+
+<your_test_sub_domain_here>:8081 {
+    respond "Hello, from your test caddy!"
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/devcontainers/go:1.24
+
+# Install xcaddy to test directly with caddy
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+# Install infomaniak caddy module for testing
+RUN git clone https://github.com/caddy-dns/infomaniak.git /workspaces/caddy-dns-infomaniak
+WORKDIR /workspaces/caddy-dns-infomaniak
+RUN go mod edit -replace github.com/libdns/infomaniak=/workspaces/libdns-infomaniak
+
+RUN mkdir /workspaces/caddy \\
+    && chown -R vscode:vscode /go \\
+    && chown -R vscode:vscode /workspaces \\
+    && ln -s /workspaces/libdns-infomaniak/.devcontainer/.caddyfile /workspaces/caddy/.caddyfile
+
+WORKDIR /workspaces/libdns-infomaniak
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "devcontainer-libdns-infomaniak",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.Go",
+				"IgorSbitnev.error-gutters"
+			]
+		}
+	},
+
+	// Tell vscode which user it should use to install the workspace for code server
+	"containerUser": "vscode",
+	// Allow access to workspace files
+	"runArgs": [
+		"--userns=keep-id:uid=1000,gid=1000"
+	],
+
+	"updateRemoteUserUID": true,
+ 	"containerEnv": {
+   		"HOME": "/home/vscode"
+	},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/libdns-infomaniak,type=bind,relabel=private",
+	"workspaceFolder": "/workspaces/libdns-infomaniak"
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please login to your infomaniak account and then navigate [here](https://manager
 The repository contains configurations for a Visual Studio Code dev container. Please install the Visual Studio Code extension `ms-vscode-remote.remote-containers` to make use of it.
 
 ### Testing With Caddy
-If you use the provided Dev Container, you can easily test your changes directly with caddy. Start by replacing the three placeholders for email, API token and domain in the `.devcontainer/.caddyfile` (make sure to never commit these changes). You can then use the commands below directly in your Dev Container.
+If you use the provided Dev Container, you can easily test your changes directly with caddy. Start by replacing the three placeholders for email, API token and domain in `.devcontainer/.caddyfile` (make sure to never commit these changes). You can then use the commands below directly in your Dev Container.
 
 After each change, you have to rebuild caddy with the following command - make sure to enter a valid version of caddy:
 `xcaddy build <caddy_version> --with dns.providers.infomaniak=/workspaces/caddy-dns-infomaniak --replace github.com/libdns/infomaniak=/workspaces/libdns-infomaniak --output /workspaces/caddy/caddy`
@@ -30,5 +30,5 @@ After each change, you have to rebuild caddy with the following command - make s
 Run caddy with the following command and monitor the output:
 `/workspaces/caddy/caddy run --config /workspaces/caddy/.caddyfile`
 
-If caddy managed to successfully issue the certificate and you would like to test from scratch again, you have to delete the previously issued certificate
+If caddy managed to successfully issue the certificate and you would like to test from scratch again, you have to delete the previously issued certificate by running
 `rm -R /home/vscode/.local/share/caddy`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ infomaniak for [`libdns`](https://github.com/libdns/libdns)
 
 [![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/infomaniak)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [infomaniak](https://infomaniak.com), allowing you to manage DNS records.
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [infomaniak](https://infomaniak.com) based on their [API reference](https://developer.infomaniak.com/docs/api/get/2/zones/%7Bzone%7D/records), allowing you to manage DNS records.
 
 ## Code example
 ```go
@@ -14,7 +14,21 @@ provider := &infomaniak.Provider{
 ```
 
 ## Create Your API Token
-Please login to your infomaniak account and then navigate [here](https://manager.infomaniak.com/v3/infomaniak-api) to issue your API access token. The scope of your token has to include "domain".
+Please login to your infomaniak account and then navigate [here](https://manager.infomaniak.com/v3/infomaniak-api) to issue your API access token. The scope of your token has to include "domain:read", "dns:read" and "dns:write".
+> :warning: All releases up to and including v0.1.3 use an unsupported API version and **require a different scope for your token**. If you use any of these releases, please make sure the "domain" scope is include for your token instead of the ones listed above.
 
+## Development
+### Setup
+The repository contains configurations for a Visual Studio Code dev container. Please install the Visual Studio Code extension `ms-vscode-remote.remote-containers` to make use of it.
 
-> :warning: The API for domains is currently not listed in the [infomaniak API reference](https://developer.infomaniak.com/docs/api). Their support told me that the API for domains is "not yet mature". The API calls in this module were implemented based on the [go-acme/lego infomaniak provider](https://github.com/go-acme/lego/tree/master/providers/dns/infomaniak) and the [acmesh-official/acme.sh infomaniak provider](https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/dns_infomaniak.sh). The API could be subject to changes.
+### Testing With Caddy
+If you use the provided Dev Container, you can easily test your changes directly with caddy. Start by replacing the three placeholders for email, API token and domain in the `.devcontainer/.caddyfile` (make sure to never commit these changes). You can then use the commands below directly in your Dev Container.
+
+After each change, you have to rebuild caddy with the following command - make sure to enter a valid version of caddy:
+`xcaddy build <caddy_version> --with dns.providers.infomaniak=/workspaces/caddy-dns-infomaniak --replace github.com/libdns/infomaniak=/workspaces/libdns-infomaniak --output /workspaces/caddy/caddy`
+
+Run caddy with the following command and monitor the output:
+`/workspaces/caddy/caddy run --config /workspaces/caddy/.caddyfile`
+
+If caddy managed to successfully issue the certificate and you would like to test from scratch again, you have to delete the previously issued certificate
+`rm -R /home/vscode/.local/share/caddy`

--- a/client.go
+++ b/client.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
-	"sync"
-
-	"github.com/libdns/libdns"
 )
 
 // Client that abstracts and calls infomaniak API
@@ -19,56 +19,21 @@ type Client struct {
 
 	// http client used for requests
 	HttpClient *http.Client
-
-	// cache of domains registered for the
-	// current infomaniak account to prevent
-	// that we have to load them for each request
-	managedZones *[]IkZone
-
-	// mutex to prevent race conditions
-	mu sync.Mutex
 }
 
 // GetDnsRecordsForZone loads all dns records for a given zone
 func (c *Client) GetDnsRecordsForZone(ctx context.Context, zone string) ([]IkRecord, error) {
-	infomaniakManagedZone, err := c.GetInfomaniakManagedZone(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, getRecordsEndpointUrl(infomaniakManagedZone), nil)
-	if err != nil {
-		return nil, err
-	}
-
 	var dnsRecords []IkRecord
-	_, err = c.doRequest(req, &dnsRecords)
+	_, err := c.doRequest(ctx, http.MethodGet, getRecordsEndpointUrl(zone), nil, &dnsRecords)
 	if err != nil {
 		return nil, err
 	}
-
-	zoneRecords := make([]IkRecord, 0)
-	for _, rec := range dnsRecords {
-		recordFqdn := libdns.AbsoluteName(rec.Source, infomaniakManagedZone.Fqdn)
-		if strings.HasSuffix(recordFqdn, zone) {
-			rec.Source = libdns.RelativeName(recordFqdn, zone)
-			cleanRecordTarget(&rec)
-			zoneRecords = append(zoneRecords, rec)
-		}
-	}
-	return zoneRecords, nil
+	unescapeTargets(dnsRecords)
+	return dnsRecords, nil
 }
 
 // CreateOrUpdateRecord creates a record if its Id property is not set, otherwise it updates the record
 func (c *Client) CreateOrUpdateRecord(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-	infomaniakManagedZone, err := c.GetInfomaniakManagedZone(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	recordFqdn := libdns.AbsoluteName(record.Source, zone)
-	record.Source = libdns.RelativeName(recordFqdn, infomaniakManagedZone.Fqdn)
-
 	rawJson, err := json.Marshal(record)
 	if err != nil {
 		return nil, err
@@ -76,69 +41,56 @@ func (c *Client) CreateOrUpdateRecord(ctx context.Context, zone string, record I
 
 	isNew := record.ID == 0
 	var method = http.MethodPost
-	var endpoint = getRecordsEndpointUrl(infomaniakManagedZone)
+	var endpoint = getRecordsEndpointUrl(zone)
 
 	if !isNew {
 		method = http.MethodPut
-		endpoint = getRecordEndpointUrl(infomaniakManagedZone, fmt.Sprint(record.ID))
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewBuffer(rawJson))
-	if err != nil {
-		return nil, err
+		endpoint = getRecordEndpointUrl(zone, fmt.Sprint(record.ID), false)
 	}
 
 	var updatedRecord IkRecord
-	_, err = c.doRequest(req, &updatedRecord)
+	_, err = c.doRequest(ctx, method, endpoint, bytes.NewBuffer(rawJson), &updatedRecord)
 	if err != nil {
 		return nil, err
 	}
-	updatedRecord.Source = libdns.RelativeName(libdns.AbsoluteName(updatedRecord.Source, infomaniakManagedZone.Fqdn), zone)
-	cleanRecordTarget(&updatedRecord)
+	unescapeTarget(&updatedRecord)
 	return &updatedRecord, nil
 }
 
 // DeleteRecord deletes an existing dns record for a given zone
 func (c *Client) DeleteRecord(ctx context.Context, zone string, recordId string) error {
-	infomaniakManagedZone, err := c.GetInfomaniakManagedZone(ctx, zone)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, getRecordEndpointUrl(infomaniakManagedZone, recordId), nil)
-	if err != nil {
-		return err
-	}
-	_, err = c.doRequest(req, nil)
+	_, err := c.doRequest(ctx, http.MethodDelete, getRecordEndpointUrl(zone, recordId, true), nil, nil)
 	return err
 }
 
-// GetInfomaniakManagedZone looks for the zone that is managed by infomaniak
-func (c *Client) GetInfomaniakManagedZone(ctx context.Context, domain string) (IkZone, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.managedZones == nil {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, getZonesEndpointUrl(domain), nil)
-		if err != nil {
-			return IkZone{}, err
-		}
-		var zones []IkZone
-		_, err = c.doRequest(req, &zones)
-		if err != nil {
-			return IkZone{}, err
-		}
-		c.managedZones = &zones
+// GetFqdnOfZoneForDomain returns the FQDN of the zone managed by infomaniak
+func (c *Client) GetFqdnOfZoneForDomain(ctx context.Context, domain string) (string, error) {
+	var zones []IkZone
+	_, err := c.doRequest(ctx, http.MethodGet, getZonesEndpointUrl(domain), nil, &zones)
+	if err != nil {
+		return "", err
 	}
-	for _, managedZone := range *c.managedZones {
+
+	sort.Slice(zones, func(a int, b int) bool {
+		return len(zones[a].Fqdn) > len(zones[b].Fqdn)
+	})
+
+	for _, managedZone := range zones {
 		if strings.HasSuffix(domain, managedZone.Fqdn) {
-			return managedZone, nil
+			return managedZone.Fqdn, nil
 		}
 	}
-	return IkZone{}, fmt.Errorf("could not find the zone managed by infomaniak for %s", domain)
+
+	return "", fmt.Errorf("could not find the zone managed by infomaniak for %s", domain)
 }
 
-// doRequest performs the API call for the given request req and parses the response's data to the given data struct - if the parameter is not nil
-func (c *Client) doRequest(req *http.Request, data any) (*IkResponse, error) {
+// doRequest performs the API call for the given parameters and parses the response's data to the given responseData struct - if the parameter is not nil
+func (c *Client) doRequest(ctx context.Context, method, url string, requestBody io.Reader, responseData any) (*IkResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -159,8 +111,8 @@ func (c *Client) doRequest(req *http.Request, data any) (*IkResponse, error) {
 		return nil, fmt.Errorf("got errors: HTTP %d: %+v", rawResp.StatusCode, string(resp.Error))
 	}
 
-	if data != nil {
-		err = json.Unmarshal(resp.Data, data)
+	if responseData != nil {
+		err = json.Unmarshal(resp.Data, responseData)
 		if err != nil {
 			return nil, err
 		}
@@ -169,26 +121,40 @@ func (c *Client) doRequest(req *http.Request, data any) (*IkResponse, error) {
 	return &resp, nil
 }
 
+// unescapeTargets makes sure all record's target value conforms to *unescaped* standard zone file syntax
+func unescapeTargets(recs []IkRecord) {
+	for i := range recs {
+		unescapeTarget(&recs[i])
+	}
+}
+
+// unescapeTarget makes sure record target value conforms to *unescaped* standard zone file syntax
+func unescapeTarget(rec *IkRecord) {
+	unquoted, err := strconv.Unquote(rec.Target)
+	if err == nil {
+		rec.Target = unquoted
+	}
+}
+
 const apiBaseUrl = "https://api.infomaniak.com"
+const recordsPath = apiBaseUrl + "/2/zones/%s/records%s"
+const recordDetailParam = "with=records_description"
 
 // getRecordEndpointUrl returns API endpoint for a specific, already existing record
-func getRecordEndpointUrl(zone IkZone, recordId string) string {
-	return fmt.Sprintf("%s/%s", getRecordsEndpointUrl(zone), recordId)
+func getRecordEndpointUrl(zone string, recordId string, isDelete bool) string {
+	param := "/" + recordId
+	if !isDelete {
+		param = param + "?" + recordDetailParam
+	}
+	return fmt.Sprintf(recordsPath, zone, param)
 }
 
 // getRecordsEndpointUrl returns API endpoint for all records of a zone
-func getRecordsEndpointUrl(zone IkZone) string {
-	return fmt.Sprintf("%s/2/zones/%s/records", apiBaseUrl, zone.Fqdn)
+func getRecordsEndpointUrl(zone string) string {
+	return fmt.Sprintf(recordsPath, zone, "?"+recordDetailParam)
 }
 
 // getRecordsEndpointUrl returns API endpoint for all records of a zone
 func getZonesEndpointUrl(domain string) string {
 	return fmt.Sprintf("%s/2/domains/%s/zones", apiBaseUrl, domain)
-}
-
-// cleanRecordTarget Target of returned record is for some types wrapper in extra quotes
-func cleanRecordTarget(record *IkRecord) {
-	if record.Type == "TXT" {
-		record.Target = record.Target[1 : len(record.Target)-1]
-	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,6 @@ package infomaniak
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,196 +17,587 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }
 
-// newHttpTestClient returns *http.Client with transport replaced to avoid making real calls
-func newHttpTestClient(fn RoundTripFunc) *http.Client {
+// aTestHttpClient returns *http.Client with transport replaced to avoid making real calls
+func aTestHttpClient(fn RoundTripFunc) *http.Client {
 	return &http.Client{
 		Transport: RoundTripFunc(fn),
 	}
 }
 
-// newTestClient returns new client that returns the given answer for an http call
-func newTestClient(resultData string, cachedZones *[]IkZone) *Client {
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
+// aTestClient returns new client that returns the given answer for an http call
+func aTestClient(resultData string) *Client {
+	httpClient := aTestHttpClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":%s}`, resultData))),
 			Header:     make(http.Header),
 		}
 	})
-	return &Client{HttpClient: httpClient, managedZones: cachedZones}
+	return &Client{HttpClient: httpClient}
 }
 
-// aResponseWithId returns the given ID as the id of a record in form of an http response
-func aResponseWithId(id int) *http.Response {
-	return aResponse(fmt.Sprintf(`"id": %d`, id))
+// aFailingTestClient returns new client that returns some kind of error when the API is called
+func aFailingTestClient(statusCode int, err string) *Client {
+	httpClient := aTestHttpClient(func(req *http.Request) *http.Response {
+		body := ""
+		if statusCode == 200 {
+			body = fmt.Sprintf(`{"result":"error", "error":%s}`, err)
+		}
+
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Header:     make(http.Header),
+		}
+	})
+	return &Client{HttpClient: httpClient}
 }
 
-// aResponse returns the given string as the data of a record in form of an http response
-func aResponse(recString string) *http.Response {
-	return &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":{%s}}`, recString))),
-		Header:     make(http.Header),
+// aRequestCapturingTestClient returns new client that allows to capture the request parameters
+func aRequestCapturingTestClient(resultData string, request *http.Request) *Client {
+	httpClient := aTestHttpClient(func(req *http.Request) *http.Response {
+		*request = *req
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":%s}`, resultData))),
+			Header:     make(http.Header),
+		}
+	})
+	return &Client{HttpClient: httpClient}
+}
+
+func Test_GetFqdnOfZoneForDomain_CallsInfomaniakEndpointWithAuthHeader(t *testing.T) {
+	zone := "sub.example.com"
+	var request http.Request
+	client := aRequestCapturingTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, zone), &request)
+	client.Token = "test-token"
+
+	client.GetFqdnOfZoneForDomain(context.TODO(), zone)
+
+	authHeader := request.Header.Get("Authorization")
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization header not correct, expected: \"%s\", actual: \"%s\"", "Bearer test-token", authHeader)
 	}
 }
 
-func Test_GetInfomaniakManagedZone_ReturnsManagedZoneForDomain(t *testing.T) {
+func Test_GetFqdnOfZoneForDomain_CallsInfomaniakEndpointWithContentTypeHeader(t *testing.T) {
+	zone := "sub.example.com"
+	var request http.Request
+	client := aRequestCapturingTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, zone), &request)
+
+	client.GetFqdnOfZoneForDomain(context.TODO(), zone)
+
+	contentTypeHeader := request.Header.Get("Content-Type")
+	if contentTypeHeader != "application/json" {
+		t.Fatalf("Content-Type header not correct, expected: \"%s\", actual: \"%s\"", "application/json", contentTypeHeader)
+	}
+}
+
+func Test_GetFqdnOfZoneForDomain_CallsInfomaniakEndpointWithGetMethod(t *testing.T) {
+	zone := "sub.example.com"
+	var request http.Request
+	client := aRequestCapturingTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, zone), &request)
+
+	client.GetFqdnOfZoneForDomain(context.TODO(), zone)
+
+	if request.Method != http.MethodGet {
+		t.Fatalf("Wrong http method used, expected: \"%s\", actual: \"%s\"", http.MethodGet, request.Method)
+	}
+}
+
+func Test_GetFqdnOfZoneForDomain_CallsCorrectInfomaniakEndpoint(t *testing.T) {
+	zone := "sub.example.com"
+	expectedEndpoint := fmt.Sprintf("https://api.infomaniak.com/2/domains/%s/zones", zone)
+	var request http.Request
+	client := aRequestCapturingTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, zone), &request)
+
+	client.GetFqdnOfZoneForDomain(context.TODO(), zone)
+
+	endpoint := request.URL.String()
+	if endpoint != expectedEndpoint {
+		t.Fatalf("Wrong endpoint used, expected: \"%s\", actual: \"%s\"", expectedEndpoint, endpoint)
+	}
+}
+
+func Test_GetFqdnOfZoneForDomain_ReturnsManagedZoneForDomain(t *testing.T) {
 	managedZone := "example.com"
-	client := newTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone), nil)
-	zone, err := client.GetInfomaniakManagedZone(context.TODO(), "subdomain."+managedZone)
+	client := aTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone))
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	zone, _ := client.GetFqdnOfZoneForDomain(context.TODO(), "subdomain."+managedZone)
 
-	if zone.Fqdn != managedZone {
-		t.Fatalf("Expected zone %s, got %s", managedZone, zone.Fqdn)
+	if zone != managedZone {
+		t.Fatalf("Expected zone %s, got %s", managedZone, zone)
 	}
 }
 
-func Test_GetInfomaniakManagedZone_ReturnsErrorIfZoneNotFound(t *testing.T) {
+func Test_GetFqdnOfZoneForDomain_ReturnsMostAccurateManagedZoneForDomain(t *testing.T) {
+	managedTopLevelZone := "example.com"
+	managedSubZone := "sub.example.com"
+	client := aTestClient(fmt.Sprintf(`[ { "fqdn":"%s" }, { "fqdn":"%s" } ]`, managedTopLevelZone, managedSubZone))
+
+	zone, _ := client.GetFqdnOfZoneForDomain(context.TODO(), "test."+managedSubZone)
+
+	if zone != managedSubZone {
+		t.Fatalf("Expected zone %s, got %s", managedSubZone, zone)
+	}
+}
+
+func Test_GetFqdnOfZoneForDomain_ReturnsErrorIfZoneNotFound(t *testing.T) {
 	managedZone := "example.com"
-	client := newTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone), nil)
-	zone, err := client.GetInfomaniakManagedZone(context.TODO(), "subdomain.test.com")
+	client := aTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone))
+
+	zone, err := client.GetFqdnOfZoneForDomain(context.TODO(), "subdomain.test.com")
 
 	if err == nil {
-		t.Fatalf("Expected error because no zone matched but got %#v", zone)
+		t.Fatalf("Expected error because no zone matched but got %s", zone)
 	}
 }
 
-func Test_GetDnsRecordsForZone_OnlyReturnsRecordsForSpecifiedZone(t *testing.T) {
-	domainName := "example.com"
-	zone := "subzone." + domainName
-	recForZone := IkRecord{ID: 1893, Source: "subzone"}
+func Test_GetFqdnOfZoneForDomain_ReturnsErrorIfApiCallFails(t *testing.T) {
+	client := aFailingTestClient(500, "")
 
-	jsonString1, err := json.Marshal(recForZone)
-	if err != nil {
-		t.Fatal(err)
-	}
-	jsonString2, err := json.Marshal(IkRecord{ID: 335, Source: "."})
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := client.GetFqdnOfZoneForDomain(context.TODO(), "subdomain.test.com")
 
-	client := newTestClient(fmt.Sprintf(`[ %s, %s ]`, jsonString1, jsonString2), &[]IkZone{{Fqdn: domainName}})
-
-	recsForZone, err := client.GetDnsRecordsForZone(context.TODO(), zone)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(recsForZone) != 1 {
-		t.Fatalf("Expected %d records, got %d", 1, len(recsForZone))
-	}
-
-	if recsForZone[0].ID != recForZone.ID {
-		t.Fatalf("Expected records with ID %d, got %d", recForZone.ID, recsForZone[0].ID)
+	if err == nil {
+		t.Fatalf("Expected error because API call failed")
 	}
 }
 
-func Test_GetDnsRecordsForZone_RemovesExtraQuotesInTargetOfTxtRecord(t *testing.T) {
-	domainName := "example.com"
-	rec := IkRecord{ID: 1893, Source: ".", Type: "TXT", Target: "\"target_value\""}
+func Test_GetFqdnOfZoneForDomain_ReturnsErrorIfApiReturnsError(t *testing.T) {
+	client := aFailingTestClient(200, "some error message")
 
-	jsonString, _ := json.Marshal(rec)
-	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domainName}})
-	recs, _ := client.GetDnsRecordsForZone(context.TODO(), domainName)
-	if recs[0].Target != "target_value" {
-		t.Fatalf("Expected %s as Target, got %s", "target_value", recs[0].Target)
+	_, err := client.GetFqdnOfZoneForDomain(context.TODO(), "subdomain.test.com")
+
+	if err == nil {
+		t.Fatalf("Expected error because infomaniak API call returned error")
 	}
 }
 
-func Test_GetDnsRecordsForZone_DoesNotRemoveExtraQuotesInTargetOfRecordOtherThanTxt(t *testing.T) {
-	domainName := "example.com"
-	rec := IkRecord{ID: 1893, Source: ".", Type: "MX", Target: "\"target_value\""}
+func Test_GetDnsRecordsForZone_CallsInfomaniakEndpointWithAuthHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("[]", &request)
+	client.Token = "test-token"
 
-	jsonString, _ := json.Marshal(rec)
-	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domainName}})
-	recs, _ := client.GetDnsRecordsForZone(context.TODO(), domainName)
-	if recs[0].Target != "\"target_value\"" {
-		t.Fatalf("Expected %s as Target, got %s", "\"target_value\"", recs[0].Target)
+	client.GetDnsRecordsForZone(context.TODO(), "sub.example.com")
+
+	authHeader := request.Header.Get("Authorization")
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization header not correct, expected: \"%s\", actual: \"%s\"", "Bearer test-token", authHeader)
 	}
 }
 
-func Test_GetDnsRecordsForZone_AdjustsSourceRelativeToGivenZone(t *testing.T) {
-	domain := "example.com"
-	zone := "test." + domain
-	rec := IkRecord{ID: 1893, Source: "sub.test"}
+func Test_GetDnsRecordsForZone_CallsInfomaniakEndpointWithContentTypeHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("[]", &request)
 
-	jsonString, _ := json.Marshal(rec)
-	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domain}})
-	recs, _ := client.GetDnsRecordsForZone(context.TODO(), zone)
-	if recs[0].Source != "sub" {
-		t.Fatalf("Expected Source %s, got %s", "sub", recs[0].Source)
+	client.GetDnsRecordsForZone(context.TODO(), "sub.example.com")
+
+	contentTypeHeader := request.Header.Get("Content-Type")
+	if contentTypeHeader != "application/json" {
+		t.Fatalf("Content-Type header not correct, expected: \"%s\", actual: \"%s\"", "application/json", contentTypeHeader)
 	}
 }
 
-func Test_CreateOrUpdateRecord_ReturnsUpdatedRecord(t *testing.T) {
-	id := 984
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
-		if req.Method != http.MethodPut {
-			t.Fatalf("Expected http method %s, got %s", http.MethodPut, req.Method)
-		}
-		return aResponseWithId(985)
-	})
+func Test_GetDnsRecordsForZone_CallsInfomaniakEndpointWithGetMethod(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("[]", &request)
 
-	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: id})
-	if rec.ID != 985 {
-		t.Fatal("Did not return updated / created record")
+	client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	if request.Method != http.MethodGet {
+		t.Fatalf("Wrong http method used, expected: \"%s\", actual: \"%s\"", http.MethodGet, request.Method)
 	}
 }
 
-func Test_CreateOrUpdateRecord_CreatesNewRecord(t *testing.T) {
-	id := 445
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
-		if req.Method != http.MethodPost {
-			t.Fatalf("Expected http method %s, got %s", http.MethodPost, req.Method)
-		}
-		return aResponseWithId(id)
-	})
+func Test_GetDnsRecordsForZone_CallsCorrectInfomaniakEndpoint(t *testing.T) {
+	zone := "sub.example.com"
+	expectedEndpoint := fmt.Sprintf("https://api.infomaniak.com/2/zones/%s/records?with=records_description", zone)
+	var request http.Request
+	client := aRequestCapturingTestClient("[]", &request)
 
-	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
-	if rec.ID != id {
-		t.Fatalf("Expected ID to be %d, got %d", id, rec.ID)
+	client.GetDnsRecordsForZone(context.TODO(), zone)
+
+	endpoint := request.URL.String()
+	if endpoint != expectedEndpoint {
+		t.Fatalf("Wrong endpoint used, expected: \"%s\", actual: \"%s\"", expectedEndpoint, endpoint)
 	}
 }
 
-func Test_CreateOrUpdateRecord_RemovesExtraQuotesInTargetOfTxtRecord(t *testing.T) {
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
-		return aResponse(`"id": 123, "type": "TXT", "target": "\"target_val\""`)
-	})
+func Test_GetDnsRecordsForZone_ParsesNSRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":25,"source":".","type":"NS","ttl":3600,"target":"ns11.infomaniak.ch","updated_at":1659958248}]`)
 
-	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
-	if rec.Target != "target_val" {
-		t.Fatalf("Expected Target to be %s, got %s", "target_val", rec.Target)
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 25, res[0].ID)
+	assertEquals(t, "Source", ".", res[0].Source)
+	assertEquals(t, "Type", "NS", res[0].Type)
+	assertEqualsInt(t, "TTL", 3600, res[0].TtlInSec)
+	assertEquals(t, "Target", "ns11.infomaniak.ch", res[0].Target)
+}
+
+func Test_GetDnsRecordsForZone_ParsesARecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":5,"source":"subdomain","type":"A","ttl":60,"target":"1.1.1.1","updated_at":182637717,"dyndns_id":7}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 5, res[0].ID)
+	assertEquals(t, "Source", "subdomain", res[0].Source)
+	assertEquals(t, "Type", "A", res[0].Type)
+	assertEqualsInt(t, "TTL", 60, res[0].TtlInSec)
+	assertEquals(t, "Target", "1.1.1.1", res[0].Target)
+}
+
+func Test_GetDnsRecordsForZone_ParsesTxtRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":35556917,"source":"alpha","type":"TXT","ttl":360,"target":"\"quotes \\\" backslashes \\\\000\"","updated_at":1445066462}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 35556917, res[0].ID)
+	assertEquals(t, "Source", "alpha", res[0].Source)
+	assertEquals(t, "Type", "TXT", res[0].Type)
+	assertEqualsInt(t, "TTL", 360, res[0].TtlInSec)
+	assertEquals(t, "Target", `quotes " backslashes \000`, res[0].Target)
+}
+
+func Test_GetDnsRecordsForZone_ParsesCaaRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":450,"source":"libdns.test","type":"CAA","ttl":3600,"target":"1 issue \"127.0.0.1\"","updated_at":7,"description":{"flags":{"value":1},"tag":{"value":"issue"}}}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 450, res[0].ID)
+	assertEquals(t, "Source", "libdns.test", res[0].Source)
+	assertEquals(t, "Type", "CAA", res[0].Type)
+	assertEqualsInt(t, "TTL", 3600, res[0].TtlInSec)
+	assertEquals(t, "Target", `1 issue "127.0.0.1"`, res[0].Target)
+	assertEqualsInt(t, "Flags", 1, res[0].Description.Flags.Value)
+	assertEquals(t, "Tag", "issue", res[0].Description.Tag.Value)
+}
+
+func Test_GetDnsRecordsForZone_ParsesCNameRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":33,"source":"test.libdns","type":"CNAME","ttl":3600,"target":"libdns.com","updated_at":5}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 33, res[0].ID)
+	assertEquals(t, "Source", "test.libdns", res[0].Source)
+	assertEquals(t, "Type", "CNAME", res[0].Type)
+	assertEqualsInt(t, "TTL", 3600, res[0].TtlInSec)
+	assertEquals(t, "Target", `libdns.com`, res[0].Target)
+}
+
+func Test_GetDnsRecordsForZone_ParsesMxRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":778,"source":"libdns.test","type":"MX","ttl":3600,"target":"7 127.0.0.1","updated_at":9,"description":{"priority":{"value":7}}}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 778, res[0].ID)
+	assertEquals(t, "Source", "libdns.test", res[0].Source)
+	assertEquals(t, "Type", "MX", res[0].Type)
+	assertEqualsInt(t, "TTL", 3600, res[0].TtlInSec)
+	assertEquals(t, "Target", `7 127.0.0.1`, res[0].Target)
+	assertEqualsInt(t, "Priority", 7, res[0].Description.Priority.Value)
+}
+
+func Test_GetDnsRecordsForZone_ParsesSrvRecordCorrectly(t *testing.T) {
+	client := aTestClient(`[{"id":73,"source":"libdns","type":"SRV","ttl":3600,"target":"10 0 5060 _sip._tcp.example.com","updated_at":7,"delegated_zone":{"id":8,"uri":"https:\/\/api.infomaniak.com\/2\/zones\/_tcp.example.com"},"description":{"priority":{"value":10},"port":{"value":5060},"weight":{"value":0},"protocol":{"value":"_tcp"}}}]`)
+
+	res, _ := client.GetDnsRecordsForZone(context.TODO(), "example.com")
+
+	assertEqualsInt(t, "ID", 73, res[0].ID)
+	assertEquals(t, "Source", "libdns", res[0].Source)
+	assertEquals(t, "Type", "SRV", res[0].Type)
+	assertEqualsInt(t, "TTL", 3600, res[0].TtlInSec)
+	assertEquals(t, "Target", `10 0 5060 _sip._tcp.example.com`, res[0].Target)
+	assertEqualsInt(t, "Priority", 10, res[0].Description.Priority.Value)
+	assertEqualsInt(t, "Weight", 0, res[0].Description.Weight.Value)
+	assertEqualsInt(t, "Port", 5060, res[0].Description.Port.Value)
+	assertEquals(t, "Protocol", "_tcp", res[0].Description.Protocol.Value)
+}
+
+func Test_GetDnsRecordsForZone_ReturnsErrorIfApiCallFails(t *testing.T) {
+	client := aFailingTestClient(500, "")
+
+	_, err := client.GetDnsRecordsForZone(context.TODO(), "subdomain.test.com")
+
+	if err == nil {
+		t.Fatalf("Expected error because API call failed")
 	}
 }
 
-func Test_CreateOrUpdateRecord_DoesNotRemoveExtraQuotesInTargetOfRecordOtherThanTxt(t *testing.T) {
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
-		return aResponse(`"id": 123, "type": "MX", "target": "\"target_val\""`)
-	})
+func Test_GetDnsRecordsForZone_ReturnsErrorIfApiReturnsError(t *testing.T) {
+	client := aFailingTestClient(200, "some error message")
 
-	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
-	if rec.Target != "\"target_val\"" {
-		t.Fatalf("Expected Target to be %s, got %s", "\"target_val\"", rec.Target)
+	_, err := client.GetDnsRecordsForZone(context.TODO(), "subdomain.test.com")
+
+	if err == nil {
+		t.Fatalf("Expected error because infomaniak API call returned error")
 	}
 }
 
-func Test_CreateOrUpdateRecord_AdjustsSourceRelativeToGivenZone(t *testing.T) {
-	domain := "example.com"
-	zone := "test." + domain
-	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
-		return aResponse(`"id": 123, "source": "sub.test"`)
-	})
+func Test_DeleteRecord_CallsInfomaniakEndpointWithAuthHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("", &request)
+	client.Token = "test-token"
 
-	client := Client{managedZones: &[]IkZone{{Fqdn: domain}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), zone, IkRecord{ID: 0})
-	if rec.Source != "sub" {
-		t.Fatalf("Expected Source %s, got %s", "sub", rec.Source)
+	client.DeleteRecord(context.TODO(), "zone.com", "23")
+
+	authHeader := request.Header.Get("Authorization")
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization header not correct, expected: \"%s\", actual: \"%s\"", "Bearer test-token", authHeader)
+	}
+}
+
+func Test_DeleteRecord_CallsInfomaniakEndpointWithContentTypeHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("", &request)
+
+	client.DeleteRecord(context.TODO(), "zone.com", "23")
+
+	contentTypeHeader := request.Header.Get("Content-Type")
+	if contentTypeHeader != "application/json" {
+		t.Fatalf("Content-Type header not correct, expected: \"%s\", actual: \"%s\"", "application/json", contentTypeHeader)
+	}
+}
+
+func Test_DeleteRecord_CallsInfomaniakEndpointWithDeleteMethod(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient("", &request)
+
+	client.DeleteRecord(context.TODO(), "zone.com", "23")
+
+	if request.Method != http.MethodDelete {
+		t.Fatalf("Wrong http method used, expected: \"%s\", actual: \"%s\"", http.MethodDelete, request.Method)
+	}
+}
+
+func Test_DeleteRecord_CallsCorrectInfomaniakEndpoint(t *testing.T) {
+	id := "333789"
+	zone := "example.zone.com"
+	expectedEndpoint := fmt.Sprintf("https://api.infomaniak.com/2/zones/%s/records/%s", zone, id)
+	var request http.Request
+	client := aRequestCapturingTestClient("", &request)
+
+	client.DeleteRecord(context.TODO(), zone, id)
+
+	endpoint := request.URL.String()
+	if endpoint != expectedEndpoint {
+		t.Fatalf("Wrong endpoint used, expected: \"%s\", actual: \"%s\"", expectedEndpoint, endpoint)
+	}
+}
+
+func Test_DeleteRecord_ReturnsErrorIfApiCallFails(t *testing.T) {
+	client := aFailingTestClient(500, "")
+
+	err := client.DeleteRecord(context.TODO(), "subdomain.test.com", "25")
+
+	if err == nil {
+		t.Fatalf("Expected error because API call failed")
+	}
+}
+
+func Test_DeleteRecord_ReturnsErrorIfApiReturnsError(t *testing.T) {
+	client := aFailingTestClient(200, "some error message")
+
+	err := client.DeleteRecord(context.TODO(), "subdomain.test.com", "83")
+
+	if err == nil {
+		t.Fatalf("Expected error because infomaniak API call returned error")
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsInfomaniakEndpointWithAuthHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+	client.Token = "test-token"
+
+	client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	authHeader := request.Header.Get("Authorization")
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization header not correct, expected: \"%s\", actual: \"%s\"", "Bearer test-token", authHeader)
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsInfomaniakEndpointWithContentTypeHeader(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+
+	client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	contentTypeHeader := request.Header.Get("Content-Type")
+	if contentTypeHeader != "application/json" {
+		t.Fatalf("Content-Type header not correct, expected: \"%s\", actual: \"%s\"", "application/json", contentTypeHeader)
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsInfomaniakEndpointWithPostMethodForNewRecords(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+
+	client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{ID: 0})
+
+	if request.Method != http.MethodPost {
+		t.Fatalf("Wrong http method used, expected: \"%s\", actual: \"%s\"", http.MethodPost, request.Method)
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsInfomaniakEndpointWithPutMethodForExistingRecords(t *testing.T) {
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+
+	client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{ID: 5})
+
+	if request.Method != http.MethodPut {
+		t.Fatalf("Wrong http method used, expected: \"%s\", actual: \"%s\"", http.MethodPut, request.Method)
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsCorrectInfomaniakEndpointForNewRecords(t *testing.T) {
+	zone := "sub.example.com"
+	expectedEndpoint := fmt.Sprintf("https://api.infomaniak.com/2/zones/%s/records?with=records_description", zone)
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+
+	client.CreateOrUpdateRecord(context.TODO(), zone, IkRecord{ID: 0})
+
+	endpoint := request.URL.String()
+	if endpoint != expectedEndpoint {
+		t.Fatalf("Wrong endpoint used, expected: \"%s\", actual: \"%s\"", expectedEndpoint, endpoint)
+	}
+}
+
+func Test_CreateOrUpdateRecord_CallsCorrectInfomaniakEndpointForExistingRecords(t *testing.T) {
+	id := 5
+	zone := "sub.example.com"
+	expectedEndpoint := fmt.Sprintf("https://api.infomaniak.com/2/zones/%s/records/%d?with=records_description", zone, id)
+	var request http.Request
+	client := aRequestCapturingTestClient(`{"id": 5}`, &request)
+
+	client.CreateOrUpdateRecord(context.TODO(), zone, IkRecord{ID: id})
+
+	endpoint := request.URL.String()
+	if endpoint != expectedEndpoint {
+		t.Fatalf("Wrong endpoint used, expected: \"%s\", actual: \"%s\"", expectedEndpoint, endpoint)
+	}
+}
+
+func Test_CreateOrUpdateRecord_ReturnsUpdatedOrCreatedRecord(t *testing.T) {
+	client := aTestClient(`{"id": 23}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
+
+	if res.ID != 23 {
+		t.Fatalf("Expected created record with ID %d to be returned, got ID %d", 23, res.ID)
+	}
+}
+
+func Test_CreateOrUpdateRecord_ParsesNSRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":25,"source":".","type":"NS","ttl":3600,"target":"ns11.infomaniak.ch","updated_at":1659958248}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 25, res.ID)
+	assertEquals(t, "Source", ".", res.Source)
+	assertEquals(t, "Type", "NS", res.Type)
+	assertEqualsInt(t, "TTL", 3600, res.TtlInSec)
+	assertEquals(t, "Target", "ns11.infomaniak.ch", res.Target)
+}
+
+func Test_CreateOrUpdateRecord_ParsesARecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":5,"source":"subdomain","type":"A","ttl":60,"target":"1.1.1.1","updated_at":182637717,"dyndns_id":7}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 5, res.ID)
+	assertEquals(t, "Source", "subdomain", res.Source)
+	assertEquals(t, "Type", "A", res.Type)
+	assertEqualsInt(t, "TTL", 60, res.TtlInSec)
+	assertEquals(t, "Target", "1.1.1.1", res.Target)
+}
+
+func Test_CreateOrUpdateRecord_ParsesTxtRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":35556917,"source":"alpha","type":"TXT","ttl":360,"target":"\"quotes \\\" backslashes \\\\000\"","updated_at":1445066462}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 35556917, res.ID)
+	assertEquals(t, "Source", "alpha", res.Source)
+	assertEquals(t, "Type", "TXT", res.Type)
+	assertEqualsInt(t, "TTL", 360, res.TtlInSec)
+	assertEquals(t, "Target", `quotes " backslashes \000`, res.Target)
+}
+
+func Test_CreateOrUpdateRecord_ParsesCaaRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":450,"source":"libdns.test","type":"CAA","ttl":3600,"target":"1 issue \"127.0.0.1\"","updated_at":7,"description":{"flags":{"value":1},"tag":{"value":"issue"}}}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 450, res.ID)
+	assertEquals(t, "Source", "libdns.test", res.Source)
+	assertEquals(t, "Type", "CAA", res.Type)
+	assertEqualsInt(t, "TTL", 3600, res.TtlInSec)
+	assertEquals(t, "Target", `1 issue "127.0.0.1"`, res.Target)
+	assertEqualsInt(t, "Flags", 1, res.Description.Flags.Value)
+	assertEquals(t, "Tag", "issue", res.Description.Tag.Value)
+}
+
+func Test_CreateOrUpdateRecord_ParsesCNameRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":33,"source":"test.libdns","type":"CNAME","ttl":3600,"target":"libdns.com","updated_at":5}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 33, res.ID)
+	assertEquals(t, "Source", "test.libdns", res.Source)
+	assertEquals(t, "Type", "CNAME", res.Type)
+	assertEqualsInt(t, "TTL", 3600, res.TtlInSec)
+	assertEquals(t, "Target", `libdns.com`, res.Target)
+}
+
+func Test_CreateOrUpdateRecord_ParsesMxRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":778,"source":"libdns.test","type":"MX","ttl":3600,"target":"7 127.0.0.1","updated_at":9,"description":{"priority":{"value":7}}}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 778, res.ID)
+	assertEquals(t, "Source", "libdns.test", res.Source)
+	assertEquals(t, "Type", "MX", res.Type)
+	assertEqualsInt(t, "TTL", 3600, res.TtlInSec)
+	assertEquals(t, "Target", `7 127.0.0.1`, res.Target)
+	assertEqualsInt(t, "Priority", 7, res.Description.Priority.Value)
+}
+
+func Test_CreateOrUpdateRecord_ParsesSrvRecordCorrectly(t *testing.T) {
+	client := aTestClient(`{"id":73,"source":"libdns","type":"SRV","ttl":3600,"target":"10 0 5060 _sip._tcp.example.com","updated_at":7,"delegated_zone":{"id":8,"uri":"https:\/\/api.infomaniak.com\/2\/zones\/_tcp.example.com"},"description":{"priority":{"value":10},"port":{"value":5060},"weight":{"value":0},"protocol":{"value":"_tcp"}}}`)
+
+	res, _ := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	assertEqualsInt(t, "ID", 73, res.ID)
+	assertEquals(t, "Source", "libdns", res.Source)
+	assertEquals(t, "Type", "SRV", res.Type)
+	assertEqualsInt(t, "TTL", 3600, res.TtlInSec)
+	assertEquals(t, "Target", `10 0 5060 _sip._tcp.example.com`, res.Target)
+	assertEqualsInt(t, "Priority", 10, res.Description.Priority.Value)
+	assertEqualsInt(t, "Weight", 0, res.Description.Weight.Value)
+	assertEqualsInt(t, "Port", 5060, res.Description.Port.Value)
+	assertEquals(t, "Protocol", "_tcp", res.Description.Protocol.Value)
+}
+
+func Test_CreateOrUpdateRecord_ReturnsErrorIfApiCallFails(t *testing.T) {
+	client := aFailingTestClient(500, "")
+
+	_, err := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	if err == nil {
+		t.Fatalf("Expected error because API call failed")
+	}
+}
+
+func Test_CreateorUpdateRecord_ReturnsErrorIfApiReturnsError(t *testing.T) {
+	client := aFailingTestClient(200, "some error message")
+
+	_, err := client.CreateOrUpdateRecord(context.TODO(), "test.com", IkRecord{})
+
+	if err == nil {
+		t.Fatalf("Expected error because infomaniak API call returned error")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -26,66 +26,70 @@ func newHttpTestClient(fn RoundTripFunc) *http.Client {
 }
 
 // newTestClient returns new client that returns the given answer for an http call
-func newTestClient(resultData string, cachedDomains *[]IkDomain) *Client {
+func newTestClient(resultData string, cachedZones *[]IkZone) *Client {
 	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":%s}`, resultData))),
+			Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":%s}`, resultData))),
 			Header:     make(http.Header),
 		}
 	})
-	return &Client{HttpClient: httpClient, domains: cachedDomains}
+	return &Client{HttpClient: httpClient, managedZones: cachedZones}
 }
 
-// anIdResponse returns the given string as the id of a record in form of an http response
-func anIdResponse(id string) *http.Response {
+// aResponseWithId returns the given ID as the id of a record in form of an http response
+func aResponseWithId(id int) *http.Response {
+	return aResponse(fmt.Sprintf(`"id": %d`, id))
+}
+
+// aResponse returns the given string as the data of a record in form of an http response
+func aResponse(recString string) *http.Response {
 	return &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":"%s"}`, id))),
+		Body:       io.NopCloser(bytes.NewBufferString(fmt.Sprintf(`{"result":"success", "data":{%s}}`, recString))),
 		Header:     make(http.Header),
 	}
 }
 
-func Test_GetDomainForZone_ReturnsDomainForZone(t *testing.T) {
-	domainName := "example.com"
-	id := 1893
-	client := newTestClient(fmt.Sprintf(`[ { "id":%d, "customer_name":"%s" } ]`, id, domainName), nil)
-	domain, err := client.getDomainForZone(context.TODO(), "subdomain."+domainName)
+func Test_GetInfomaniakManagedZone_ReturnsManagedZoneForDomain(t *testing.T) {
+	managedZone := "example.com"
+	client := newTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone), nil)
+	zone, err := client.GetInfomaniakManagedZone(context.TODO(), "subdomain."+managedZone)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if domain.ID != id {
-		t.Fatalf("Expected domain ID %d, got %d", id, domain.ID)
+	if zone.Fqdn != managedZone {
+		t.Fatalf("Expected zone %s, got %s", managedZone, zone.Fqdn)
 	}
 }
 
-func Test_GetDomainForZone_ReturnsErrorIfDomainForZoneNotFound(t *testing.T) {
-	domainName := "example.com"
-	client := newTestClient(fmt.Sprintf(`[ { "id":10, "customer_name":"%s" } ]`, domainName), nil)
-	domain, err := client.getDomainForZone(context.TODO(), "subdomain.test.com")
+func Test_GetInfomaniakManagedZone_ReturnsErrorIfZoneNotFound(t *testing.T) {
+	managedZone := "example.com"
+	client := newTestClient(fmt.Sprintf(`[ { "fqdn":"%s" } ]`, managedZone), nil)
+	zone, err := client.GetInfomaniakManagedZone(context.TODO(), "subdomain.test.com")
 
 	if err == nil {
-		t.Fatalf("Expected error because no domain matched but got %#v", domain)
+		t.Fatalf("Expected error because no zone matched but got %#v", zone)
 	}
 }
 
 func Test_GetDnsRecordsForZone_OnlyReturnsRecordsForSpecifiedZone(t *testing.T) {
 	domainName := "example.com"
 	zone := "subzone." + domainName
-	recForZone := IkRecord{ID: "1893", SourceIdn: zone}
+	recForZone := IkRecord{ID: 1893, Source: "subzone"}
 
 	jsonString1, err := json.Marshal(recForZone)
 	if err != nil {
 		t.Fatal(err)
 	}
-	jsonString2, err := json.Marshal(IkRecord{ID: "335", SourceIdn: domainName})
+	jsonString2, err := json.Marshal(IkRecord{ID: 335, Source: "."})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	client := newTestClient(fmt.Sprintf(`[ %s, %s ]`, jsonString1, jsonString2), &[]IkDomain{{Name: "example.com", ID: 100}})
+	client := newTestClient(fmt.Sprintf(`[ %s, %s ]`, jsonString1, jsonString2), &[]IkZone{{Fqdn: domainName}})
 
 	recsForZone, err := client.GetDnsRecordsForZone(context.TODO(), zone)
 	if err != nil {
@@ -97,38 +101,113 @@ func Test_GetDnsRecordsForZone_OnlyReturnsRecordsForSpecifiedZone(t *testing.T) 
 	}
 
 	if recsForZone[0].ID != recForZone.ID {
-		t.Fatalf("Expected records with ID %s, got %s", recForZone.ID, recsForZone[0].ID)
+		t.Fatalf("Expected records with ID %d, got %d", recForZone.ID, recsForZone[0].ID)
 	}
 }
 
-func Test_CreateOrUpdateRecord_UpdatesExistingRecord(t *testing.T) {
-	id := "984"
+func Test_GetDnsRecordsForZone_RemovesExtraQuotesInTargetOfTxtRecord(t *testing.T) {
+	domainName := "example.com"
+	rec := IkRecord{ID: 1893, Source: ".", Type: "TXT", Target: "\"target_value\""}
+
+	jsonString, _ := json.Marshal(rec)
+	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domainName}})
+	recs, _ := client.GetDnsRecordsForZone(context.TODO(), domainName)
+	if recs[0].Target != "target_value" {
+		t.Fatalf("Expected %s as Target, got %s", "target_value", recs[0].Target)
+	}
+}
+
+func Test_GetDnsRecordsForZone_DoesNotRemoveExtraQuotesInTargetOfRecordOtherThanTxt(t *testing.T) {
+	domainName := "example.com"
+	rec := IkRecord{ID: 1893, Source: ".", Type: "MX", Target: "\"target_value\""}
+
+	jsonString, _ := json.Marshal(rec)
+	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domainName}})
+	recs, _ := client.GetDnsRecordsForZone(context.TODO(), domainName)
+	if recs[0].Target != "\"target_value\"" {
+		t.Fatalf("Expected %s as Target, got %s", "\"target_value\"", recs[0].Target)
+	}
+}
+
+func Test_GetDnsRecordsForZone_AdjustsSourceRelativeToGivenZone(t *testing.T) {
+	domain := "example.com"
+	zone := "test." + domain
+	rec := IkRecord{ID: 1893, Source: "sub.test"}
+
+	jsonString, _ := json.Marshal(rec)
+	client := newTestClient(fmt.Sprintf(`[ %s]`, jsonString), &[]IkZone{{Fqdn: domain}})
+	recs, _ := client.GetDnsRecordsForZone(context.TODO(), zone)
+	if recs[0].Source != "sub" {
+		t.Fatalf("Expected Source %s, got %s", "sub", recs[0].Source)
+	}
+}
+
+func Test_CreateOrUpdateRecord_ReturnsUpdatedRecord(t *testing.T) {
+	id := 984
 	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
 		if req.Method != http.MethodPut {
 			t.Fatalf("Expected http method %s, got %s", http.MethodPut, req.Method)
 		}
-		return anIdResponse("985")
+		return aResponseWithId(985)
 	})
 
-	client := Client{domains: &[]IkDomain{{Name: "example.com", ID: 100}}, HttpClient: httpClient}
+	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
 	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: id})
-	if rec.ID != id {
-		t.Fatal("ID of already existing record was updated")
+	if rec.ID != 985 {
+		t.Fatal("Did not return updated / created record")
 	}
 }
 
 func Test_CreateOrUpdateRecord_CreatesNewRecord(t *testing.T) {
-	id := "445"
+	id := 445
 	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
 		if req.Method != http.MethodPost {
 			t.Fatalf("Expected http method %s, got %s", http.MethodPost, req.Method)
 		}
-		return anIdResponse(id)
+		return aResponseWithId(id)
 	})
 
-	client := Client{domains: &[]IkDomain{{Name: "example.com", ID: 100}}, HttpClient: httpClient}
-	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: ""})
+	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
+	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
 	if rec.ID != id {
-		t.Fatalf("Expected ID to be %s, got %s", id, rec.ID)
+		t.Fatalf("Expected ID to be %d, got %d", id, rec.ID)
+	}
+}
+
+func Test_CreateOrUpdateRecord_RemovesExtraQuotesInTargetOfTxtRecord(t *testing.T) {
+	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
+		return aResponse(`"id": 123, "type": "TXT", "target": "\"target_val\""`)
+	})
+
+	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
+	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
+	if rec.Target != "target_val" {
+		t.Fatalf("Expected Target to be %s, got %s", "target_val", rec.Target)
+	}
+}
+
+func Test_CreateOrUpdateRecord_DoesNotRemoveExtraQuotesInTargetOfRecordOtherThanTxt(t *testing.T) {
+	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
+		return aResponse(`"id": 123, "type": "MX", "target": "\"target_val\""`)
+	})
+
+	client := Client{managedZones: &[]IkZone{{Fqdn: "example.com"}}, HttpClient: httpClient}
+	rec, _ := client.CreateOrUpdateRecord(context.TODO(), "example.com", IkRecord{ID: 0})
+	if rec.Target != "\"target_val\"" {
+		t.Fatalf("Expected Target to be %s, got %s", "\"target_val\"", rec.Target)
+	}
+}
+
+func Test_CreateOrUpdateRecord_AdjustsSourceRelativeToGivenZone(t *testing.T) {
+	domain := "example.com"
+	zone := "test." + domain
+	httpClient := newHttpTestClient(func(req *http.Request) *http.Response {
+		return aResponse(`"id": 123, "source": "sub.test"`)
+	})
+
+	client := Client{managedZones: &[]IkZone{{Fqdn: domain}}, HttpClient: httpClient}
+	rec, _ := client.CreateOrUpdateRecord(context.TODO(), zone, IkRecord{ID: 0})
+	if rec.Source != "sub" {
+		t.Fatalf("Expected Source %s, got %s", "sub", rec.Source)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/infomaniak
 
 go 1.18
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0-beta.1 h1:KIf4wLfsrEpXpZ3vmc/poM8zCATXT2klbdPe6hyOBjQ=
+github.com/libdns/libdns v1.0.0-beta.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/mappers.go
+++ b/mappers.go
@@ -1,49 +1,168 @@
 package infomaniak
 
 import (
+	"net/netip"
 	"strconv"
+	"strings"
 	"time"
-
-	"fmt"
 
 	"github.com/libdns/libdns"
 )
-
-// Default priority - infomaniak does not return any value
-const defaultPriority = 10
 
 // Default TTL that is applied if none is provided - infomaniak requires a TTL
 const defaultTtlSecs = 300
 
 // ToLibDnsRecord maps a infomaniak dns record to a libdns record
-func (ikr *IkRecord) ToLibDnsRecord() libdns.Record {
-	return libdns.Record{
-		ID:       fmt.Sprint(ikr.ID),
-		Type:     ikr.Type,
-		Name:     ikr.Source,
-		Value:    ikr.Target,
-		TTL:      time.Duration(ikr.TtlInSec),
-		Priority: defaultPriority,
+func (ikr *IkRecord) ToLibDnsRecord(zoneMapping *ZoneMapping) (libdns.Record, error) {
+	switch ikr.Type {
+	case "A", "AAAA":
+		return ikr.toAddressRecord(zoneMapping)
+	case "CAA":
+		return ikr.toCaaRecord(zoneMapping), nil
+	case "CNAME":
+		return ikr.toCNameRecord(zoneMapping), nil
+	case "MX":
+		return ikr.toMxRecord(zoneMapping), nil
+	case "NS":
+		return ikr.toNsRecord(zoneMapping), nil
+	case "SRV":
+		return ikr.toServiceRecord(zoneMapping), nil
+	case "TXT":
+		return ikr.toTextRecord(zoneMapping), nil
+	default:
+		return libdns.RR{
+			Name: zoneMapping.ToRelativeLibdnsName(ikr.Source),
+			TTL:  ikr.getTtlAsTimeDuration(),
+			Type: ikr.Type,
+			Data: ikr.Target,
+		}.Parse()
 	}
 }
 
-// ToInfomaniakRecord maps a libdns record to a infomaniak dns record
-func ToInfomaniakRecord(libdnsRec *libdns.Record) IkRecord {
-	ikRec := IkRecord{
-		ID:       0,
-		Type:     libdnsRec.Type,
-		Source:   libdnsRec.Name,
-		Target:   libdnsRec.Value,
-		TtlInSec: int(libdnsRec.TTL),
+// getTtlAsTimeDuration returns the TTL of a infomaniak DNS record as a time duration
+func (ikr *IkRecord) getTtlAsTimeDuration() time.Duration {
+	return time.Duration(ikr.TtlInSec * int(time.Second))
+}
+
+// toAddressRecord parses an infomaniak DNS record as a libdns Address record
+func (ikr *IkRecord) toAddressRecord(zoneMapping *ZoneMapping) (libdns.Address, error) {
+	addr, err := netip.ParseAddr(ikr.Target)
+	if err != nil {
+		return libdns.Address{}, err
 	}
 
-	id, err := strconv.Atoi(libdnsRec.ID)
+	return libdns.Address{
+		Name: zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:  ikr.getTtlAsTimeDuration(),
+		IP:   addr,
+	}, nil
+}
+
+// toCaaRecord parses an infomaniak DNS record as a libdns CAA record
+func (ikr *IkRecord) toCaaRecord(zoneMapping *ZoneMapping) libdns.CAA {
+	return libdns.CAA{
+		Name:  zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:   ikr.getTtlAsTimeDuration(),
+		Flags: uint8(ikr.Description.Flags.Value),
+		Tag:   ikr.Description.Tag.Value,
+		Value: ikr.getLastTargetValue(),
+	}
+}
+
+// toCNameRecord parses an infomaniak DNS record as a libdns CNAME record
+func (ikr *IkRecord) toCNameRecord(zoneMapping *ZoneMapping) libdns.CNAME {
+	return libdns.CNAME{
+		Name:   zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:    ikr.getTtlAsTimeDuration(),
+		Target: ikr.Target,
+	}
+}
+
+// toMxRecord parses an infomaniak DNS record as a libdns MX record
+func (ikr *IkRecord) toMxRecord(zoneMapping *ZoneMapping) libdns.MX {
+	return libdns.MX{
+		Name:       zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:        ikr.getTtlAsTimeDuration(),
+		Preference: uint16(ikr.Description.Priority.Value),
+		Target:     ikr.getLastTargetValue(),
+	}
+}
+
+// toNsRecord parses an infomaniak DNS record as a libdns NS record
+func (ikr *IkRecord) toNsRecord(zoneMapping *ZoneMapping) libdns.NS {
+	return libdns.NS{
+		Name:   zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:    ikr.getTtlAsTimeDuration(),
+		Target: ikr.Target,
+	}
+}
+
+// toServiceRecord parses an infomaniak DNS record as a libdns SRV record
+func (ikr *IkRecord) toServiceRecord(zoneMapping *ZoneMapping) libdns.SRV {
+	parts := strings.SplitN(ikr.Source, ".", 2)
+	return libdns.SRV{
+		Service:   strings.TrimPrefix(parts[0], "_"),
+		Transport: strings.TrimPrefix(ikr.Description.Protocol.Value, "_"),
+		Name:      zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:       ikr.getTtlAsTimeDuration(),
+		Priority:  uint16(ikr.Description.Priority.Value),
+		Weight:    uint16(ikr.Description.Weight.Value),
+		Port:      uint16(ikr.Description.Port.Value),
+		Target:    ikr.getLastTargetValue(),
+	}
+}
+
+// toTextRecord parses an infomaniak DNS record as a libdns TXT record
+func (ikr *IkRecord) toTextRecord(zoneMapping *ZoneMapping) libdns.TXT {
+	return libdns.TXT{
+		Name: zoneMapping.ToRelativeLibdnsName(ikr.Source),
+		TTL:  ikr.getTtlAsTimeDuration(),
+		Text: ikr.Target,
+	}
+}
+
+// getLastTargetValue parses last value of the record's target
+func (ikr *IkRecord) getLastTargetValue() string {
+	parts := strings.Split(ikr.Target, " ")
+	targetValue := parts[len(parts)-1]
+	unquoted, err := strconv.Unquote(targetValue)
 	if err == nil {
-		ikRec.ID = id
+		targetValue = unquoted
+	}
+	return targetValue
+}
+
+// ToRelativeLibdnsName converts a relative name from the infomaniak managed zone
+// to the input zone of the libdns caller
+func (zoneMapping *ZoneMapping) ToRelativeLibdnsName(relativeName string) string {
+	return zoneMapping.convertZone(relativeName, zoneMapping.InfomaniakManagedZone, zoneMapping.LibDnsZone)
+}
+
+// ToRelativeInfomaniakName converts a relative name from input zone of the libdns caller
+// to the infomaniak managed zone
+func (zoneMapping *ZoneMapping) ToRelativeInfomaniakName(relativeName string) string {
+	return zoneMapping.convertZone(relativeName, zoneMapping.LibDnsZone, zoneMapping.InfomaniakManagedZone)
+}
+
+// convertZone converts a relative name from a source zone to a target zone
+func (zoneMapping *ZoneMapping) convertZone(relativeName string, sourceZone string, targetZone string) string {
+	return libdns.RelativeName(libdns.AbsoluteName(relativeName, sourceZone), targetZone)
+}
+
+// ToInfomaniakRecord maps a libdns record to a infomaniak dns record
+func ToInfomaniakRecord(libdnsRec libdns.Record, zoneMapping *ZoneMapping) IkRecord {
+	rr := libdnsRec.RR()
+
+	rec := IkRecord{
+		Source:   zoneMapping.ToRelativeInfomaniakName(rr.Name),
+		Type:     rr.Type,
+		TtlInSec: int(rr.TTL.Seconds()),
+		Target:   rr.Data,
 	}
 
-	if ikRec.TtlInSec <= 0 {
-		ikRec.TtlInSec = defaultTtlSecs
+	if rec.TtlInSec < 60 {
+		rec.TtlInSec = defaultTtlSecs
 	}
-	return ikRec
+
+	return rec
 }

--- a/mappers_test.go
+++ b/mappers_test.go
@@ -2,45 +2,213 @@ package infomaniak
 
 import (
 	"testing"
-
-	"fmt"
+	"time"
 
 	"github.com/libdns/libdns"
 )
 
-func Test_ToLibDnsRecord_MapsAllProperties(t *testing.T) {
+func Test_ToLibDnsRecord_CreatesAddressRecordForARecord(t *testing.T) {
 	ikRec := IkRecord{
-		ID:       123456,
-		Type:     "MX",
+		Source:   "test.zone",
+		Type:     "A",
 		Target:   "127.0.0.1",
 		TtlInSec: 3600,
 	}
 
-	libRec := ikRec.ToLibDnsRecord()
-	assertEquals(t, "ID", fmt.Sprint(ikRec.ID), libRec.ID)
-	assertEquals(t, "Type", ikRec.Type, libRec.Type)
-	assertEquals(t, "Value", ikRec.Target, libRec.Value)
-	assertEqualsInt(t, "TTL", ikRec.TtlInSec, 3600)
-	assertEqualsInt(t, "Priority", 10, int(libRec.Priority))
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	addressRec, isTypeOk := libRec.(libdns.Address)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.Address type")
+	}
+	assertEquals(t, "Name", "test", addressRec.Name)
+	assertEquals(t, "IP", "127.0.0.1", addressRec.IP.String())
+	assertEqualsInt(t, "TTL", 3600, int(addressRec.TTL.Seconds()))
+}
+
+func Test_ToLibDnsRecord_FailsToCreateAddressRecordForInvalidIP(t *testing.T) {
+	ikRec := IkRecord{
+		Target: "127-0-0-1",
+		Type:   "A",
+	}
+
+	_, err := ikRec.ToLibDnsRecord(&ZoneMapping{})
+	if err == nil {
+		t.Fatalf("Expected error due to invalid IP")
+	}
+}
+
+func Test_ToLibDnsRecord_CreatesAddressRecordForAAAARecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:   "test.zone",
+		Type:     "AAAA",
+		Target:   "::1",
+		TtlInSec: 60,
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	addressRec, isTypeOk := libRec.(libdns.Address)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.Address type")
+	}
+	assertEquals(t, "Name", "test", addressRec.Name)
+	assertEquals(t, "IP", "::1", addressRec.IP.String())
+	assertEqualsInt(t, "TTL", 60, int(addressRec.TTL.Seconds()))
+}
+
+func Test_ToLibDnsRecord_CreatesCaaRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:      "subdomain.zone",
+		Type:        "CAA",
+		Target:      `1 issue "example.com"`,
+		TtlInSec:    60,
+		Description: IkRecordDescription{Tag: IkStringValueAttribute{Value: "issue"}, Flags: IkIntValueAttribute{Value: 1}},
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	caaRec, isTypeOk := libRec.(libdns.CAA)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.CAA type")
+	}
+	assertEquals(t, "Name", "subdomain", caaRec.Name)
+	assertEquals(t, "Tag", "issue", caaRec.Tag)
+	assertEqualsInt(t, "Flags", 1, int(caaRec.Flags))
+	assertEqualsInt(t, "TTL", 60, int(caaRec.TTL.Seconds()))
+	assertEquals(t, "Value", "example.com", caaRec.Value)
+}
+
+func Test_ToLibDnsRecord_CreatesCNameRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:   "subdomain.zone",
+		Type:     "CNAME",
+		Target:   "subdomain.alias.com",
+		TtlInSec: 60,
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	cnameRec, isTypeOk := libRec.(libdns.CNAME)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.CNAME type")
+	}
+	assertEquals(t, "Name", "subdomain", cnameRec.Name)
+	assertEquals(t, "Target", "subdomain.alias.com", cnameRec.Target)
+	assertEqualsInt(t, "TTL", 60, int(cnameRec.TTL.Seconds()))
+}
+
+func Test_ToLibDnsRecord_CreatesMxRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:      "test.zone",
+		Type:        "MX",
+		Target:      "23 1.1.1.1",
+		TtlInSec:    60,
+		Description: IkRecordDescription{Priority: IkIntValueAttribute{Value: 23}},
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	mxRec, isTypeOk := libRec.(libdns.MX)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.MX type")
+	}
+	assertEquals(t, "Name", "test", mxRec.Name)
+	assertEquals(t, "Target", "1.1.1.1", mxRec.Target)
+	assertEqualsInt(t, "TTL", 60, int(mxRec.TTL.Seconds()))
+	assertEqualsInt(t, "Preference", 23, int(mxRec.Preference))
+}
+
+func Test_ToLibDnsRecord_CreatesNsRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:   "test.zone",
+		Type:     "NS",
+		Target:   "ns11.infomaniak.ch",
+		TtlInSec: 60,
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.com", LibDnsZone: "zone.example.com"})
+	nsRec, isTypeOk := libRec.(libdns.NS)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.NS type")
+	}
+	assertEquals(t, "Name", "test", nsRec.Name)
+	assertEquals(t, "Target", "ns11.infomaniak.ch", nsRec.Target)
+	assertEqualsInt(t, "TTL", 60, int(nsRec.TTL.Seconds()))
+}
+
+func Test_ToLibDnsRecord_CreatesServiceRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:      "_sip.test",
+		Type:        "SRV",
+		Target:      "10 0 5060 target.test.com",
+		TtlInSec:    60,
+		Description: IkRecordDescription{Port: IkIntValueAttribute{Value: 5060}, Priority: IkIntValueAttribute{Value: 10}, Weight: IkIntValueAttribute{Value: 0}, Protocol: IkStringValueAttribute{Value: "_tcp"}},
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "example.domain.com", LibDnsZone: "domain.com"})
+	srvRec, isTypeOk := libRec.(libdns.SRV)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.SRV type")
+	}
+	assertEquals(t, "Service", "sip", srvRec.Service)
+	assertEquals(t, "Transport", "tcp", srvRec.Transport)
+	assertEquals(t, "Name", "_sip.test.example", srvRec.Name)
+	assertEqualsInt(t, "TTL", 60, int(srvRec.TTL.Seconds()))
+	assertEqualsInt(t, "Priority", 10, int(srvRec.Priority))
+	assertEqualsInt(t, "Weight", 0, int(srvRec.Weight))
+	assertEqualsInt(t, "Port", 5060, int(srvRec.Port))
+	assertEquals(t, "Target", "target.test.com", srvRec.Target)
+}
+
+func Test_ToLibDnsRecord_CreatesTxtRecord(t *testing.T) {
+	ikRec := IkRecord{
+		Source:   "example",
+		Type:     "TXT",
+		Target:   "This is an awesome domain! Definitely not spammy.",
+		TtlInSec: 60,
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "domain.com", LibDnsZone: "example.domain.com"})
+	txtRec, isTypeOk := libRec.(libdns.TXT)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.TXT type")
+	}
+	assertEquals(t, "Name", "@", txtRec.Name)
+	assertEquals(t, "Text", "This is an awesome domain! Definitely not spammy.", txtRec.Text)
+	assertEqualsInt(t, "TTL", 60, int(txtRec.TTL.Seconds()))
+}
+
+func Test_ToLibDnsRecord_CreatesRrForNonTypedRecordType(t *testing.T) {
+	ikRec := IkRecord{
+		Source:   "test",
+		Type:     "RNAME",
+		Target:   "admin.example.com",
+		TtlInSec: 60,
+	}
+
+	libRec, _ := ikRec.ToLibDnsRecord(&ZoneMapping{InfomaniakManagedZone: "domain.com", LibDnsZone: "test.domain.com"})
+	rec, isTypeOk := libRec.(libdns.RR)
+	if !isTypeOk {
+		t.Fatalf("Expected libdns.RR type")
+	}
+	assertEquals(t, "Name", "@", rec.Name)
+	assertEquals(t, "Type", "RNAME", rec.Type)
+	assertEquals(t, "Text", "admin.example.com", rec.Data)
+	assertEqualsInt(t, "TTL", 60, int(rec.TTL.Seconds()))
 }
 
 func Test_ToInfomaniakRecord_MapsAllProperties(t *testing.T) {
-	libRec := libdns.Record{
-		ID:       "123456",
-		Type:     "MX",
-		Value:    "127.0.0.1",
-		TTL:      3600,
-		Priority: 17,
+	libRec := libdns.RR{
+		Name: "@",
+		Type: "MX",
+		Data: "7 127.0.0.1",
+		TTL:  time.Duration(3600 * time.Second),
 	}
 
-	ikRec := ToInfomaniakRecord(&libRec)
-	assertEquals(t, "ID", libRec.ID, fmt.Sprint(ikRec.ID))
-	assertEquals(t, "Type", libRec.Type, ikRec.Type)
-	assertEquals(t, "Value", libRec.Value, ikRec.Target)
-	assertEqualsInt(t, "TTL", int(libRec.TTL), ikRec.TtlInSec)
+	ikRec := ToInfomaniakRecord(&libRec, &ZoneMapping{InfomaniakManagedZone: "domain.com", LibDnsZone: "test.domain.com"})
+	assertEquals(t, "Source", "test", ikRec.Source)
+	assertEquals(t, "Type", "MX", ikRec.Type)
+	assertEquals(t, "Target", "7 127.0.0.1", ikRec.Target)
+	assertEqualsInt(t, "TTL", 3600, ikRec.TtlInSec)
 }
 
 func Test_ToInfomaniakRecord_DefaultTtlIsAppliedIfNoTtlProvided(t *testing.T) {
-	ikRec := ToInfomaniakRecord(&libdns.Record{})
-	assertEqualsInt(t, "TTL", defaultTtlSecs, int(ikRec.TtlInSec))
+	ikRec := ToInfomaniakRecord(&libdns.RR{}, &ZoneMapping{})
+	assertEqualsInt(t, "TTL", 300, ikRec.TtlInSec)
 }

--- a/mappers_test.go
+++ b/mappers_test.go
@@ -3,36 +3,25 @@ package infomaniak
 import (
 	"testing"
 
+	"fmt"
+
 	"github.com/libdns/libdns"
 )
 
 func Test_ToLibDnsRecord_MapsAllProperties(t *testing.T) {
 	ikRec := IkRecord{
-		ID:       "123456",
+		ID:       123456,
 		Type:     "MX",
 		Target:   "127.0.0.1",
 		TtlInSec: 3600,
-		Priority: 17,
 	}
 
-	libRec := ikRec.ToLibDnsRecord("")
-	assertEquals(t, "ID", ikRec.ID, libRec.ID)
+	libRec := ikRec.ToLibDnsRecord()
+	assertEquals(t, "ID", fmt.Sprint(ikRec.ID), libRec.ID)
 	assertEquals(t, "Type", ikRec.Type, libRec.Type)
 	assertEquals(t, "Value", ikRec.Target, libRec.Value)
-	assertEqualsInt(t, "TTL", int(ikRec.TtlInSec), int(int64(libRec.TTL)))
-	assertEqualsInt(t, "Priority", int(ikRec.Priority), int(libRec.Priority))
-}
-
-func Test_ToLibDnsRecord_ReturnsRelativeName(t *testing.T) {
-	subzone := "sub"
-	zone := "example.com"
-
-	ikRec := IkRecord{
-		SourceIdn: subzone + "." + zone,
-	}
-
-	libRec := ikRec.ToLibDnsRecord(zone)
-	assertEquals(t, "Name", subzone, libRec.Name)
+	assertEqualsInt(t, "TTL", ikRec.TtlInSec, 3600)
+	assertEqualsInt(t, "Priority", 10, int(libRec.Priority))
 }
 
 func Test_ToInfomaniakRecord_MapsAllProperties(t *testing.T) {
@@ -44,27 +33,14 @@ func Test_ToInfomaniakRecord_MapsAllProperties(t *testing.T) {
 		Priority: 17,
 	}
 
-	ikRec := ToInfomaniakRecord(&libRec, "")
-	assertEquals(t, "ID", libRec.ID, ikRec.ID)
+	ikRec := ToInfomaniakRecord(&libRec)
+	assertEquals(t, "ID", libRec.ID, fmt.Sprint(ikRec.ID))
 	assertEquals(t, "Type", libRec.Type, ikRec.Type)
 	assertEquals(t, "Value", libRec.Value, ikRec.Target)
-	assertEqualsInt(t, "TTL", int(libRec.TTL), int(ikRec.TtlInSec))
-	assertEqualsInt(t, "Priority", int(libRec.Priority), int(ikRec.Priority))
+	assertEqualsInt(t, "TTL", int(libRec.TTL), ikRec.TtlInSec)
 }
 
 func Test_ToInfomaniakRecord_DefaultTtlIsAppliedIfNoTtlProvided(t *testing.T) {
-	ikRec := ToInfomaniakRecord(&libdns.Record{}, "")
+	ikRec := ToInfomaniakRecord(&libdns.Record{})
 	assertEqualsInt(t, "TTL", defaultTtlSecs, int(ikRec.TtlInSec))
-}
-
-func Test_ToInfomaniakRecord_DefaultPriorityIsAppliedIfPriority(t *testing.T) {
-	ikRec := ToInfomaniakRecord(&libdns.Record{}, "")
-	assertEqualsInt(t, "Priority", defaultPriority, int(ikRec.Priority))
-}
-
-func Test_ToInfomaniakRecord_SetsAbsoluteNameToSource(t *testing.T) {
-	subzone := "sub"
-	zone := "example.com"
-	ikRec := ToInfomaniakRecord(&libdns.Record{Name: subzone}, zone)
-	assertEquals(t, "SourceIdn", subzone+"."+zone, ikRec.SourceIdn)
 }

--- a/provider.go
+++ b/provider.go
@@ -2,9 +2,9 @@ package infomaniak
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -19,186 +19,260 @@ type Provider struct {
 	//infomaniak client used to call API
 	client IkClient
 
-	//mutex to prevent race conditions
-	mu sync.Mutex
+	//mutex to prevent race conditions when initializing client
+	mu_client sync.Mutex
+
+	//mutex to prevent race conditions when performing request
+	mu_req sync.Mutex
 }
 
-// GetRecords lists all the records in the zone.
+// GetRecords returns all the records in the DNS zone.
+//
+// DNSKEY and DS are DNSSEC-related record types that are included in the output.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	ikRecords, err := p.getClient().GetDnsRecordsForZone(ctx, zone)
+	zones, err := p.getZoneMapping(ctx, zone)
 	if err != nil {
-		return nil, err
+		return []libdns.Record{}, err
+	}
+
+	ikRecords, err := p.getRecordsInZone(ctx, zones)
+	if err != nil {
+		return []libdns.Record{}, err
 	}
 
 	libdnsRecords := make([]libdns.Record, 0, len(ikRecords))
 	for _, rec := range ikRecords {
-		libdnsRecords = append(libdnsRecords, rec.ToLibDnsRecord())
+		r, err := rec.ToLibDnsRecord(zones)
+		if err != nil {
+			return []libdns.Record{}, err
+		}
+		libdnsRecords = append(libdnsRecords, r)
 	}
 
 	return libdnsRecords, nil
 }
 
-// getRecordsByCoordinates returns the existing records in this zone by their coordinates
-func (p *Provider) getRecordsByCoordinates(ctx context.Context, zone string) (map[string][]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	records, err := p.GetRecords(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	recordsByCoordinats := make(map[string][]libdns.Record)
-	for _, rec := range records {
-		coordinates := getCoordinates(rec)
-		recordsWithSameCoordinates := recordsByCoordinats[coordinates]
-		if recordsWithSameCoordinates == nil {
-			recordsWithSameCoordinates = make([]libdns.Record, 0)
-		}
-		recordsWithSameCoordinates = append(recordsWithSameCoordinates, rec)
-		recordsByCoordinats[coordinates] = recordsWithSameCoordinates
-	}
-	return recordsByCoordinats, nil
-}
-
-// getCoordinates returns the coordinates of a record
-func getCoordinates(record libdns.Record) string {
-	return fmt.Sprintf("%s-%s", record.Name, record.Type)
-}
-
-// AppendRecords adds records to the zone. It returns the records that were added.
+// AppendRecords creates the inputted records in the given zone and returns
+// the populated records that were created. It never changes existing records.
+//
+// Therefore, it makes little sense to use this method with CNAME-type
+// records since if there are no existing records with the same name, it
+// behaves the same as [libdns.RecordSetter.SetRecords], and if there are
+// existing records with the same name, it will either fail or leave the
+// zone in an invalid state.
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	mergedRecs, err := p.getRecordsMergedWithAlreadyExistingOnes(ctx, zone, records)
+	zones, err := p.getZoneMapping(ctx, zone)
 	if err != nil {
-		return nil, err
+		return []libdns.Record{}, err
 	}
+
+	p.mu_req.Lock()
+	defer p.mu_req.Unlock()
 
 	createdRecs := make([]libdns.Record, 0)
-	for _, rec := range mergedRecs {
-		if rec.ID == "" {
-			createdRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec))
-			if err != nil {
-				return nil, err
-			}
-			createdRecs = append(createdRecs, createdRec.ToLibDnsRecord())
+	for _, rec := range records {
+		createdIkRec, err := p.getClient().CreateOrUpdateRecord(ctx, zones.InfomaniakManagedZone, ToInfomaniakRecord(rec.RR(), zones))
+		if err != nil {
+			return []libdns.Record{}, err
 		}
+		createdRec, err := createdIkRec.ToLibDnsRecord(zones)
+		if err != nil {
+			return []libdns.Record{}, err
+		}
+		createdRecs = append(createdRecs, createdRec)
 	}
 	return createdRecs, nil
 }
 
-// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
-// It returns the updated records.
+// SetRecords updates the zone so that the records described in the input are
+// reflected in the output.
+//
+// For any (name, type) pair in the input, SetRecords ensures that the only
+// records in the output zone with that (name, type) pair are those that were
+// provided in the input.
+//
+// In RFC 9499 terms, SetRecords appends, modifies, or deletes records in the
+// zone so that for each RRset in the input, the records provided in the input
+// are the only members of their RRset in the output zone.
+//
+// DNSSEC-related records of type DS are supported.
+//
+// Calls to SetRecords are not to be presumed atomic; that is, if err == nil,
+// then all of the requested changes were made; if err != nil, then some changes
+// might have been applied already. In other words, errors may result in partial
+// changes to the zone.
+//
+// If SetRecords is used to add a CNAME record to a name with other existing
+// non-DNSSEC records, implementations may either fail with an error, add
+// the CNAME and leave the other records in place (in violation of the DNS
+// standards), or add the CNAME and remove the other preexisting records.
+// Therefore, users should proceed with caution when using SetRecords with
+// CNAME records.
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	recsToSet, err := p.getRecordsMergedWithAlreadyExistingOnes(ctx, zone, records)
+	zones, err := p.getZoneMapping(ctx, zone)
 	if err != nil {
-		return nil, err
+		return []libdns.Record{}, err
 	}
 
-	createdOrUpdatedRecs := make([]libdns.Record, 0)
-	for _, rec := range recsToSet {
-		updatedRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec))
-		if err != nil {
-			return nil, err
+	p.mu_req.Lock()
+	defer p.mu_req.Unlock()
+
+	recordIdsByCoords, err := p.getExistingRecordIdsByCoordinates(ctx, zones)
+	if err != nil {
+		return []libdns.Record{}, err
+	}
+
+	setRecs := make([]libdns.Record, 0)
+	for _, rec := range records {
+		rr := rec.RR()
+		coords := fmt.Sprintf("%s-%s", libdns.AbsoluteName(rr.Name, zone), rr.Type)
+		existingRecordIds := recordIdsByCoords[coords]
+
+		if existingRecordIds != nil {
+			for _, id := range existingRecordIds {
+				err := p.getClient().DeleteRecord(ctx, zones.InfomaniakManagedZone, id)
+				if err != nil {
+					return setRecs, err
+				}
+			}
+			recordIdsByCoords[coords] = nil
 		}
-		createdOrUpdatedRecs = append(createdOrUpdatedRecs, updatedRec.ToLibDnsRecord())
-	}
 
-	return createdOrUpdatedRecs, nil
+		updatedIkRec, err := p.getClient().CreateOrUpdateRecord(ctx, zones.InfomaniakManagedZone, ToInfomaniakRecord(rec, zones))
+		if err != nil {
+			return setRecs, err
+		}
+
+		setRec, err := updatedIkRec.ToLibDnsRecord(zones)
+		if err != nil {
+			return setRecs, err
+		}
+		setRecs = append(setRecs, setRec)
+	}
+	return setRecs, nil
 }
 
-// DeleteRecords deletes the records from the zone. It returns the records that were deleted.
-func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	recsToDelete, err := p.getRecordsMergedWithAlreadyExistingOnes(ctx, zone, records)
+// getExistingRecordIdsByCoordinates returns the existing records in this zone by their fqdn-type
+func (p *Provider) getExistingRecordIdsByCoordinates(ctx context.Context, zones *ZoneMapping) (map[string][]string, error) {
+	records, err := p.getRecordsInZone(ctx, zones)
 	if err != nil {
 		return nil, err
+	}
+
+	result := make(map[string][]string)
+	for _, rec := range records {
+		coordinates := fmt.Sprintf("%s-%s", libdns.AbsoluteName(rec.Source, zones.InfomaniakManagedZone), rec.Type)
+		recordsWithSameCoordinates := result[coordinates]
+		if recordsWithSameCoordinates == nil {
+			recordsWithSameCoordinates = make([]string, 0)
+		}
+		recordsWithSameCoordinates = append(recordsWithSameCoordinates, strconv.Itoa(rec.ID))
+		result[coordinates] = recordsWithSameCoordinates
+	}
+	return result, nil
+}
+
+// DeleteRecords deletes the given records from the zone if they exist in the
+// zone and exactly match the input. If the input records do not exist in the
+// zone, they are silently ignored. DeleteRecords returns only the the records
+// that were deleted, and does not return any records that were provided in the
+// input but did not exist in the zone.
+//
+// DeleteRecords only deletes records from the zone that *exactly* match the
+// input records—that is, the name, type, TTL, and value all must be identical
+// to a record in the zone for it to be deleted.
+//
+// As a special case, you may leave any of the fields [libdns.Record.Type],
+// [libdns.Record.TTL], or [libdns.Record.Value] empty ("", 0, and ""
+// respectively). In this case, DeleteRecords will delete any records that
+// match the other fields, regardless of the value of the fields that were left
+// empty. Note that this behavior does *not* apply to the [libdns.Record.Name]
+// field, which must always be specified.
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	zones, err := p.getZoneMapping(ctx, zone)
+	if err != nil {
+		return []libdns.Record{}, err
+	}
+
+	p.mu_req.Lock()
+	defer p.mu_req.Unlock()
+
+	existingRecs, err := p.getRecordsInZone(ctx, zones)
+	if err != nil {
+		return []libdns.Record{}, err
 	}
 
 	deletedRecs := make([]libdns.Record, 0)
-	for _, rec := range recsToDelete {
-		if rec.ID != "" {
-			err := p.getClient().DeleteRecord(ctx, zone, rec.ID)
-			if err != nil {
-				return nil, err
+	for _, recToDelete := range records {
+		rrToDelete := recToDelete.RR()
+		remainingRecs := make([]IkRecord, 0)
+		for _, existingRec := range existingRecs {
+			if !isDeleteRecord(zones, &rrToDelete, &existingRec) {
+				remainingRecs = append(remainingRecs, existingRec)
+			} else {
+				resultRec, err := existingRec.ToLibDnsRecord(zones)
+				if err != nil {
+					return deletedRecs, err
+				}
+
+				err = p.getClient().DeleteRecord(ctx, zones.InfomaniakManagedZone, strconv.Itoa(existingRec.ID))
+				if err != nil {
+					return deletedRecs, err
+				}
+				deletedRecs = append(deletedRecs, resultRec)
 			}
-			deletedRecs = append(deletedRecs, rec)
 		}
+		existingRecs = remainingRecs
 	}
 	return deletedRecs, nil
 }
 
-// getRecordsMergedWithAlreadyExistingOnes returns records with an ID immediately, checks for records without ID if a record with the same coordinates
-// already exists, if yes, then it returns the updated already existing records otherwise the new record
-func (p *Provider) getRecordsMergedWithAlreadyExistingOnes(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	result := make([]libdns.Record, 0)
-	recsWithoutId := make([]libdns.Record, 0)
-
-	for _, rec := range records {
-		if rec.ID == "" {
-			recsWithoutId = append(recsWithoutId, rec)
-		} else {
-			result = append(result, rec)
-		}
-	}
-
-	if len(recsWithoutId) > 0 {
-		mergedRecs, err := p.mergeRecordsWithExistingOnes(ctx, zone, recsWithoutId)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, mergedRecs...)
-	}
-	return result, nil
-}
-
-// mergeRecordsWithExistingOnes takes a list of records without ID. If one or multiple records with the same coordinates already exist, these records' data
-// are updated and returned, otherwise the new record is returned without any ID set
-func (p *Provider) mergeRecordsWithExistingOnes(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	zone = getWithoutTrailingDot(zone)
-	if len(records) <= 0 {
-		return make([]libdns.Record, 0), nil
-	}
-	existingRecords, err := p.getRecordsByCoordinates(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]libdns.Record, 0)
-	for _, rec := range records {
-		if rec.ID != "" {
-			return nil, errors.New("got record that already exists as parameter")
-		}
-		recordsWithSameCoords := existingRecords[getCoordinates(rec)]
-		if len(recordsWithSameCoords) > 0 {
-			for _, existingRec := range recordsWithSameCoords {
-				copy := rec
-				copy.ID = existingRec.ID
-				result = append(result, copy)
-			}
-		} else {
-			result = append(result, rec)
-		}
-	}
-	return result, nil
+// isDeleteRecord returns true when the existing record matches the record that should be deleted
+func isDeleteRecord(zoneMapping *ZoneMapping, rrToDelete *libdns.RR, existingRec *IkRecord) bool {
+	return libdns.AbsoluteName(rrToDelete.Name, zoneMapping.LibDnsZone) == libdns.AbsoluteName(existingRec.Source, zoneMapping.InfomaniakManagedZone) &&
+		(rrToDelete.TTL == 0 || rrToDelete.TTL == existingRec.getTtlAsTimeDuration()) &&
+		(rrToDelete.Type == "" || rrToDelete.Type == existingRec.Type) &&
+		(rrToDelete.Data == "" || rrToDelete.Data == existingRec.Target)
 }
 
 // getClient returns a new instance of the infomaniak API client
 func (p *Provider) getClient() IkClient {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu_client.Lock()
+	defer p.mu_client.Unlock()
 	if p.client == nil {
 		p.client = &Client{Token: p.APIToken, HttpClient: http.DefaultClient}
 	}
 	return p.client
 }
 
-// getWithoutTrailingDot returns a given string without any trailing dot
-func getWithoutTrailingDot(s string) string {
-	for strings.HasSuffix(s, ".") {
-		s = strings.TrimSuffix(s, ".")
+// getZoneMapping returns the DNS zone that is mangaged by infomaniak and the input zone
+// from the libdns caller without a trailing dot
+func (p *Provider) getZoneMapping(ctx context.Context, zone string) (*ZoneMapping, error) {
+	libdnsZone := strings.TrimSuffix(zone, ".")
+	infomaniakZone, err := p.getClient().GetFqdnOfZoneForDomain(ctx, libdnsZone)
+	if err != nil {
+		return nil, err
 	}
-	return s
+	return &ZoneMapping{
+		InfomaniakManagedZone: infomaniakZone,
+		LibDnsZone:            libdnsZone,
+	}, nil
+}
+
+// getRecordsInZone returns the records that are in theinput zone from the libdns caller
+func (p *Provider) getRecordsInZone(ctx context.Context, zones *ZoneMapping) ([]IkRecord, error) {
+	recs, err := p.getClient().GetDnsRecordsForZone(ctx, zones.InfomaniakManagedZone)
+	if err != nil {
+		return []IkRecord{}, err
+	}
+
+	result := make([]IkRecord, 0)
+	for _, rec := range recs {
+		if strings.HasSuffix(libdns.AbsoluteName(rec.Source, zones.InfomaniakManagedZone), zones.LibDnsZone) {
+			result = append(result, rec)
+		}
+	}
+	return result, nil
 }
 
 // Interface guards

--- a/provider.go
+++ b/provider.go
@@ -33,7 +33,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 
 	libdnsRecords := make([]libdns.Record, 0, len(ikRecords))
 	for _, rec := range ikRecords {
-		libdnsRecords = append(libdnsRecords, rec.ToLibDnsRecord(zone))
+		libdnsRecords = append(libdnsRecords, rec.ToLibDnsRecord())
 	}
 
 	return libdnsRecords, nil
@@ -76,11 +76,11 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	createdRecs := make([]libdns.Record, 0)
 	for _, rec := range mergedRecs {
 		if rec.ID == "" {
-			createdRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec, zone))
+			createdRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec))
 			if err != nil {
 				return nil, err
 			}
-			createdRecs = append(createdRecs, createdRec.ToLibDnsRecord(zone))
+			createdRecs = append(createdRecs, createdRec.ToLibDnsRecord())
 		}
 	}
 	return createdRecs, nil
@@ -97,11 +97,11 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 
 	createdOrUpdatedRecs := make([]libdns.Record, 0)
 	for _, rec := range recsToSet {
-		updatedRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec, zone))
+		updatedRec, err := p.getClient().CreateOrUpdateRecord(ctx, zone, ToInfomaniakRecord(&rec))
 		if err != nil {
 			return nil, err
 		}
-		createdOrUpdatedRecs = append(createdOrUpdatedRecs, updatedRec.ToLibDnsRecord(zone))
+		createdOrUpdatedRecs = append(createdOrUpdatedRecs, updatedRec.ToLibDnsRecord())
 	}
 
 	return createdOrUpdatedRecs, nil

--- a/provider_test.go
+++ b/provider_test.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"strconv"
 	"testing"
-
-	"fmt"
+	"time"
 
 	"github.com/libdns/libdns"
 )
 
 // TestClient instance of IkClient used to mock API calls
 type TestClient struct {
-	getter  func(ctx context.Context, zone string) ([]IkRecord, error)
-	setter  func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error)
-	deleter func(ctx context.Context, zone string, id string) error
+	getter     func(ctx context.Context, zone string) ([]IkRecord, error)
+	setter     func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error)
+	deleter    func(ctx context.Context, zone string, id string) error
+	zoneGetter func(ctx context.Context, domain string) (string, error)
 }
 
 // GetDnsRecordsForZone implementation to fulfill IkClient interface
@@ -32,321 +32,606 @@ func (c *TestClient) DeleteRecord(ctx context.Context, zone string, id string) e
 	return c.deleter(ctx, zone, id)
 }
 
+// GetFqdnOfZoneForDomain implementation to fulfill IkClient interface
+func (c *TestClient) GetFqdnOfZoneForDomain(ctx context.Context, domain string) (string, error) {
+	return c.zoneGetter(ctx, domain)
+}
+
 // assertEquals helper function that throws an error if the actual string value is not the expected value
 func assertEquals(t *testing.T, name string, expected string, actual string) {
 	if expected != actual {
-		t.Fatalf("Expected %s=%s, got %s=%s", name, expected, name, actual)
+		t.Fatalf("Expected %s \"%s\", got \"%s\"", name, expected, actual)
 	}
 }
 
 // assertEqualsInt helper function that throws an error if the actual int value is not the expected value
 func assertEqualsInt(t *testing.T, name string, expected int, actual int) {
-	assertEquals(t, name, convertIntToString(expected), convertIntToString(actual))
+	assertEquals(t, name, strconv.Itoa(expected), strconv.Itoa(actual))
 }
 
-// convertIntToString converts an int value to a string
-func convertIntToString(number int) string {
-	return strconv.FormatInt(int64(number), 10)
-}
-
-func Test_GetRecords_ReturnsRecords(t *testing.T) {
-	subDomain := "subdomain"
-	expectedRec := IkRecord{ID: 1893, Type: "AAAA", Source: subDomain, Target: "ns11.infomaniak.ch", TtlInSec: 301}
-	client := TestClient{getter: func(ctx context.Context, zone string) ([]IkRecord, error) { return []IkRecord{expectedRec}, nil }}
-	provider := Provider{client: &client}
-	result, _ := provider.GetRecords(context.TODO(), "example.com")
-
-	if len(result) != 1 {
-		t.Fatalf("Expected %d records, got %d", 1, len(result))
-	}
-
-	actualRec := result[0]
-	assertEquals(t, "ID", fmt.Sprint(expectedRec.ID), actualRec.ID)
-	assertEquals(t, "Name", subDomain, actualRec.Name)
-	assertEqualsInt(t, "TTL", int(expectedRec.TtlInSec), int(actualRec.TTL))
-	assertEquals(t, "Type", expectedRec.Type, actualRec.Type)
-	assertEquals(t, "Value", expectedRec.Target, actualRec.Value)
-	assertEqualsInt(t, "Priority", 10, int(actualRec.Priority))
-}
-
-func Test_GetRecords_RemovesTrailingDotsFromZone(t *testing.T) {
-	zoneWithoutSuffix := "example.com"
-
-	client := TestClient{getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
-		if zone != zoneWithoutSuffix {
-			t.Fatalf("Expected zone to be %s, was %s", zoneWithoutSuffix, zone)
-		}
-		return []IkRecord{}, nil
+func Test_GetZoneMapping_RemovesTrailingDotFromLibDnsZoneBeforeCallingClient(t *testing.T) {
+	var zone string
+	client := TestClient{zoneGetter: func(ctx context.Context, z string) (string, error) {
+		zone = z
+		return z, nil
 	}}
 	provider := Provider{client: &client}
-	provider.GetRecords(context.TODO(), zoneWithoutSuffix+".")
+
+	provider.getZoneMapping(context.TODO(), "zone.example.com.")
+
+	assertEquals(t, "Zone", "zone.example.com", zone)
 }
 
-func Test_AppendRecords_DoesNotAppendRecordWithId(t *testing.T) {
-	client := TestClient{
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			t.Fatalf("Expected that append is not called for record with ID")
-			return nil, nil
-		},
-	}
+func Test_GetZoneMapping_WorksIfProvidedZoneHasNoTrailingDot(t *testing.T) {
+	var zone string
+	client := TestClient{zoneGetter: func(ctx context.Context, argZone string) (string, error) {
+		zone = argZone
+		return argZone, nil
+	}}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{ID: "1893"}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(appendedRec) > 0 {
-		t.Fatalf("Expected 0 appended records, got %d", len(appendedRec))
-	}
+
+	provider.getZoneMapping(context.TODO(), "zone.example.com")
+
+	assertEquals(t, "Zone", "zone.example.com", zone)
 }
 
-func Test_AppendRecords_AppendsNotExistingRecord(t *testing.T) {
-	id := 12345
-	methodCalled := false
-	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) { return []IkRecord{}, nil },
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if methodCalled {
-				t.Fatalf("Expected append method to be only called once")
-			} else {
-				methodCalled = true
-			}
-			return &IkRecord{ID: id}, nil
-		},
-	}
+func Test_GetZoneMapping_ReturnsLibDnsZoneWithoutTrailingDot(t *testing.T) {
+	client := TestClient{zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil }}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be appended but was not")
-	}
-	if len(appendedRec) != 1 {
-		t.Fatalf("Expected 1 appended record, got %d", len(appendedRec))
-	}
-	if appendedRec[0].ID != fmt.Sprint(id) {
-		t.Fatalf("Expected appended record to be updated with ID %d, ID was %s", id, appendedRec[0].ID)
-	}
+
+	res, _ := provider.getZoneMapping(context.TODO(), "zone.example.com.")
+
+	assertEquals(t, "Zone", "zone.example.com", res.LibDnsZone)
 }
 
-func Test_AppendRecords_DoesNotAppendAlreadyExistingRecord(t *testing.T) {
-	recType := "AAAA"
-	name := "Test1"
-	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
-			return []IkRecord{{Source: name, Type: recType}}, nil
-		},
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			t.Fatalf("Expected that append is not called for already existing record")
-			return nil, nil
-		},
-	}
+func Test_GetZoneMapping_ReturnsInfomaniakManagedZone(t *testing.T) {
+	client := TestClient{zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "zone.managed.com", nil }}
 	provider := Provider{client: &client}
-	appendedRec, err := provider.AppendRecords(context.TODO(), "", []libdns.Record{{ID: "222", Type: recType, Name: name}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(appendedRec) > 0 {
-		t.Fatalf("Expected 0 appended records, got %d", len(appendedRec))
-	}
+
+	res, _ := provider.getZoneMapping(context.TODO(), "zone.example.com.")
+
+	assertEquals(t, "Zone", "zone.managed.com", res.InfomaniakManagedZone)
 }
 
-func Test_AppendRecords_RemovesTrailingDotsFromZone(t *testing.T) {
-	zoneWithoutSuffix := "example.com"
-
+func Test_GetRecords_PassesZoneManagedByInfomaniakToClient(t *testing.T) {
+	var zone string
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			zone = argZone
 			return []IkRecord{}, nil
 		},
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if zone != zoneWithoutSuffix {
-				t.Fatalf("Expected zone to be %s, was %s", zoneWithoutSuffix, zone)
-			}
-			return &IkRecord{}, nil
+	}
+	provider := Provider{client: &client}
+
+	provider.GetRecords(context.TODO(), "zone.example.com")
+
+	assertEquals(t, "Zone", "example.com", zone)
+}
+
+func Test_GetRecords_ReturnsRecord(t *testing.T) {
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{IkRecord{Source: "zone", Type: "libdns_infomaniak_test"}}, nil
 		},
 	}
 	provider := Provider{client: &client}
-	provider.AppendRecords(context.TODO(), zoneWithoutSuffix+".", []libdns.Record{{Name: "@"}})
+
+	res, _ := provider.GetRecords(context.TODO(), "zone.example.com")
+	if len(res) == 0 {
+		t.Fatalf("Did not get any record")
+	}
+
+	if res[0].(libdns.RR).Type != "libdns_infomaniak_test" {
+		t.Fatalf("Did not get expected record")
+	}
 }
 
-func Test_SetRecords_CreatesNewRecord(t *testing.T) {
-	methodCalled := false
+func Test_GetRecords_DoesNotReturnRecordInParentZone(t *testing.T) {
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) { return []IkRecord{}, nil },
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if methodCalled {
-				t.Fatalf("Expected set method to be only called once")
-			} else {
-				methodCalled = true
-			}
-			return &IkRecord{}, nil
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{IkRecord{Source: "@"}}, nil
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be appended but was not")
-	}
-	if len(setRec) != 1 {
-		t.Fatalf("Expected 1 set record, got %d", len(setRec))
+
+	res, _ := provider.GetRecords(context.TODO(), "zone.example.com")
+	if len(res) != 0 {
+		t.Fatalf("Got record but did not expect any")
 	}
 }
 
-func Test_SetRecords_UpdatesExistingRecordById(t *testing.T) {
-	id := 789
-	methodCalled := false
+func Test_AppendRecords_PassesZoneManagedByInfomaniakToClient(t *testing.T) {
+	var zone string
 	client := TestClient{
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if methodCalled {
-				t.Fatalf("Expected set method to be only called once")
-			} else if record.ID == id {
-				methodCalled = true
-			}
-			return &IkRecord{ID: id}, nil
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			zone = argZone
+			return &record, nil
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{ID: fmt.Sprint(id)}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be update but was not")
-	}
-	if len(setRec) != 1 {
-		t.Fatalf("Expected 1 set record, got %d", len(setRec))
-	}
+
+	provider.AppendRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.Address{}})
+
+	assertEquals(t, "Zone", "example.com", zone)
 }
 
-func Test_SetRecords_UpdatesExistingRecordByNameAndTypeIfNoIdProvided(t *testing.T) {
-	id := 2247
-	recType := "MX"
-	methodCalled := false
+func Test_AppendRecords_PassesRecordToClient(t *testing.T) {
+	var passedRecord IkRecord
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
-			return []IkRecord{{ID: id, Type: recType}}, nil
-		},
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if methodCalled {
-				t.Fatalf("Expected set method to be only called once")
-			} else if record.ID == id {
-				methodCalled = true
-			}
-			return &IkRecord{ID: id}, nil
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			passedRecord = record
+			return &record, nil
 		},
 	}
 	provider := Provider{client: &client}
-	setRec, err := provider.SetRecords(context.TODO(), "", []libdns.Record{{Type: recType}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be update but was not")
-	}
-	if len(setRec) != 1 {
-		t.Fatalf("Expected 1 set record, got %d", len(setRec))
-	}
-	if setRec[0].ID != fmt.Sprint(id) {
-		t.Fatalf("Expected returned record to be updated with ID %d, ID was %s", id, setRec[0].ID)
+
+	provider.AppendRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.RR{Type: "libdns_infomaniak_test"}})
+
+	if passedRecord.Type != "libdns_infomaniak_test" {
+		t.Fatalf("Did not pass expected record")
 	}
 }
 
-func Test_SetRecords_RemovesTrailingDotsFromZone(t *testing.T) {
-	zoneWithoutSuffix := "example.com"
-
+func Test_AppendRecords_ReturnsCreatedRecord(t *testing.T) {
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			return &IkRecord{Type: "libdns_infomaniak_test"}, nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.AppendRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.RR{}})
+
+	if len(res) == 0 {
+		t.Fatalf("Did not get any record")
+	}
+
+	if res[0].(libdns.RR).Type != "libdns_infomaniak_test" {
+		t.Fatalf("Did not get expected record")
+	}
+}
+
+func Test_SetRecords_PassesZoneManagedByInfomaniakToClient(t *testing.T) {
+	var zone string
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{}, nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			zone = argZone
+			return &record, nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.Address{}})
+
+	assertEquals(t, "Zone", "example.com", zone)
+}
+
+func Test_SetRecords_PassesRecordToClient(t *testing.T) {
+	var passedRecord IkRecord
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{}, nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			passedRecord = record
+			return &record, nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.RR{Type: "libdns_infomaniak_test"}})
+
+	if passedRecord.Type != "libdns_infomaniak_test" {
+		t.Fatalf("Did not pass expected record")
+	}
+}
+
+func Test_SetRecords_ReturnsCreatedRecord(t *testing.T) {
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{}, nil },
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) {
+			return &IkRecord{Type: "libdns_infomaniak_test"}, nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.SetRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.RR{}})
+
+	if len(res) == 0 {
+		t.Fatalf("Did not get any record")
+	}
+
+	if res[0].(libdns.RR).Type != "libdns_infomaniak_test" {
+		t.Fatalf("Did not get expected record")
+	}
+}
+
+func Test_SetRecords_DeletesRecordWithSameTypeAndSource(t *testing.T) {
+	existingRec := IkRecord{Type: "type", Source: "sub"}
+	newRec := libdns.RR{Type: "type", Name: "sub.test"}
+
+	deleteCalled := false
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec}, nil
+		},
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) { return &record, nil },
+		deleter: func(ctx context.Context, zone, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "test.example.com", []libdns.Record{newRec})
+
+	if deleteCalled {
+		t.Fatalf("Expected existing record to be deleted, but was not")
+	}
+}
+
+func Test_SetRecords_DeletesAlreadyExistingRecordsOnlyOnce(t *testing.T) {
+	existingRec := IkRecord{Type: "test_type", Source: "sub"}
+	newRec1 := libdns.RR{Type: "test_type", Name: "sub"}
+	newRec2 := libdns.RR{Type: "test_type", Name: "sub"}
+
+	deleteCalled := 0
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec}, nil
+		},
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) { return &record, nil },
+		deleter: func(ctx context.Context, zone, id string) error {
+			deleteCalled = deleteCalled + 1
+			return nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "example.com", []libdns.Record{newRec1, newRec2})
+
+	if deleteCalled != 1 {
+		t.Fatalf("Expected existing record to be deleted once, delete was called %d times", deleteCalled)
+	}
+}
+
+func Test_SetRecords_DoesNotDeleteExistingRecordOfDifferentType(t *testing.T) {
+	existingRec := IkRecord{Type: "type1", Source: "sub"}
+	newRec := libdns.RR{Type: "type2", Name: "sub"}
+
+	deleteCalled := false
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec}, nil
+		},
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) { return &record, nil },
+		deleter: func(ctx context.Context, zone, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "example.com", []libdns.Record{newRec})
+
+	if deleteCalled {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_SetRecords_DoesNotDeleteExistingRecordWithDifferentSource(t *testing.T) {
+	existingRec := IkRecord{Type: "type", Source: "sub1"}
+	newRec := libdns.RR{Type: "type", Name: "sub2"}
+
+	deleteCalled := false
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec}, nil
+		},
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) { return &record, nil },
+		deleter: func(ctx context.Context, zone, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "example.com", []libdns.Record{newRec})
+
+	if deleteCalled {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_SetRecords_DoesNotDeleteExistingRecordInParentZone(t *testing.T) {
+	existingRec := IkRecord{Type: "type", Source: "@"}
+	newRec := libdns.RR{Type: "type", Name: "@"}
+
+	deleteCalled := false
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec}, nil
+		},
+		setter: func(ctx context.Context, argZone string, record IkRecord) (*IkRecord, error) { return &record, nil },
+		deleter: func(ctx context.Context, zone, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	provider := Provider{client: &client}
+
+	provider.SetRecords(context.TODO(), "subzone.example.com", []libdns.Record{newRec})
+
+	if deleteCalled {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_DeleteRecords_LoadsExistingRecordsWithInfomaniakManagedZone(t *testing.T) {
+	var zone string
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			zone = argZone
 			return []IkRecord{}, nil
 		},
-		setter: func(ctx context.Context, zone string, record IkRecord) (*IkRecord, error) {
-			if zone != zoneWithoutSuffix {
-				t.Fatalf("Expected zone to be %s, was %s", zoneWithoutSuffix, zone)
-			}
-			return &IkRecord{}, nil
-		},
+		deleter: func(ctx context.Context, argZone, id string) error { return nil },
 	}
 	provider := Provider{client: &client}
-	provider.SetRecords(context.TODO(), zoneWithoutSuffix+".", []libdns.Record{{Name: "@"}})
+
+	provider.DeleteRecords(context.TODO(), "zone.example.com", []libdns.Record{libdns.Address{}})
+
+	assertEquals(t, "Zone", "example.com", zone)
 }
 
-func Test_DeleteRecords_DoesNotDeleteRecordWithoutIdWhoseNameAndTypeDoesNotMatchWithAnyExistingRecord(t *testing.T) {
+func Test_DeleteRecords_DeletesExistingRecordWithInfomaniakManagedZone(t *testing.T) {
+	existingRec := IkRecord{Source: "sub.zone"}
+	recToDelete := libdns.RR{Name: "sub"}
+
+	var zone string
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) { return []IkRecord{}, nil },
-		deleter: func(ctx context.Context, zone string, id string) error {
-			t.Fatalf("Expected that delete is not called for record without ID")
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter: func(ctx context.Context, argZone, id string) error {
+			zone = argZone
 			return nil
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(context.TODO(), "", []libdns.Record{{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(deletedRecs) > 0 {
-		t.Fatalf("Expected 0 deleted records, got %d", len(deletedRecs))
-	}
+
+	provider.DeleteRecords(context.TODO(), "zone.example.com", []libdns.Record{recToDelete})
+
+	assertEquals(t, "Zone", "example.com", zone)
 }
 
-func Test_Delete_Records_DeletesRecordWithSameNameAndTypeIfGivenRecordHasNoId(t *testing.T) {
-	subDomain := "sub"
-	recId := 23
-	recType := "A"
+func Test_DeleteRecords_DeletesMatchingExistingRecord(t *testing.T) {
+	existingRec := IkRecord{ID: 1893, Source: "sub1"}
+	nonMatchingExistingRec := IkRecord{ID: 23, Source: "sub2"}
+	recToDelete := libdns.RR{Name: "sub1"}
 
-	methodCalled := false
+	deletedIds := []string{}
 	client := TestClient{
-		getter: func(ctx context.Context, zone string) ([]IkRecord, error) {
-			return []IkRecord{{ID: recId, Source: subDomain, Type: recType}}, nil
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter: func(ctx context.Context, argZone string) ([]IkRecord, error) {
+			return []IkRecord{existingRec, nonMatchingExistingRec}, nil
 		},
-		deleter: func(ctx context.Context, zone string, id string) error {
-			if methodCalled {
-				t.Fatalf("Expected delete method to be only called once")
-			} else if fmt.Sprint(recId) == id {
-				methodCalled = true
-			}
+		deleter: func(ctx context.Context, argZone, id string) error {
+			deletedIds = append(deletedIds, id)
 			return nil
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{{Type: recType, Name: subDomain}})
-	if err != nil {
-		t.Fatal(err)
+
+	provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(deletedIds) != 1 {
+		t.Fatalf("Nothing was deleted")
 	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be deleted but was not")
-	}
-	if len(deletedRecs) != 1 {
-		t.Fatalf("Expected 1 deleted record, got %d", len(deletedRecs))
-	}
-	if deletedRecs[0].ID != fmt.Sprint(recId) {
-		t.Fatalf("Expected that record with id %d is deleted, got id %s", recId, deletedRecs[0].ID)
+
+	if deletedIds[0] != "1893" {
+		t.Fatalf("Expected ID %s to be deleted, got %s", "1893", deletedIds[0])
 	}
 }
 
-func Test_DeleteRecords_DeletesRecordWithId(t *testing.T) {
-	methodCalled := false
-	rec := libdns.Record{ID: "5557"}
+func Test_DeleteRecords_DoesNotTryToDeleteNonExistingRecord(t *testing.T) {
+	deleteCalled := false
 	client := TestClient{
-		deleter: func(ctx context.Context, zone string, id string) error {
-			if methodCalled {
-				t.Fatalf("Expected delete method to be only called once")
-			} else if rec.ID == id {
-				methodCalled = true
-			}
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{}, nil },
+		deleter: func(ctx context.Context, argZone, id string) error {
+			deleteCalled = true
 			return nil
 		},
 	}
 	provider := Provider{client: &client}
-	deletedRecs, err := provider.DeleteRecords(context.TODO(), "", []libdns.Record{rec})
-	if err != nil {
-		t.Fatal(err)
+
+	provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{libdns.RR{Name: "sub1"}})
+
+	if deleteCalled {
+		t.Fatalf("Delete was called although not expected")
 	}
-	if !methodCalled {
-		t.Fatalf("Expected record to be deleted but was not")
+}
+
+func Test_DeleteRecords_DeletesExistingRecordOnlyOnce(t *testing.T) {
+	existingRec := IkRecord{ID: 1893, Source: "sub1"}
+	recToDelete := libdns.RR{Name: "sub1"}
+	recToDelete2 := libdns.RR{Name: "sub1"}
+
+	deleteCallCount := 0
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter: func(ctx context.Context, argZone, id string) error {
+			deleteCallCount = deleteCallCount + 1
+			return nil
+		},
 	}
-	if len(deletedRecs) != 1 {
-		t.Fatalf("Expected 1 deleted record, got %d", len(deletedRecs))
+	provider := Provider{client: &client}
+
+	provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete, recToDelete2})
+
+	if deleteCallCount != 1 {
+		t.Fatalf("Expected for delete only to be called once, was called %d", deleteCallCount)
+	}
+}
+
+func Test_DeleteRecords_ReturnsDeletedRecord(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Type: "test_type"}
+	recToDelete := libdns.RR{Name: "sub1"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 1 {
+		t.Fatalf("Expected 1 deleted record, got %d", len(res))
+	}
+
+	if res[0].(libdns.RR).Type != "test_type" {
+		t.Fatalf("Method did not return deleted record")
+	}
+}
+
+func Test_DeleteRecords_DoesNotDeleteRecordOfParentZone(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Target: "127.0.0.1"}
+	recToDelete := libdns.RR{Name: "sub1", Data: "127.0.0.1"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return "example.com", nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "test.example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 0 {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_DeleteRecords_DeletesRecordWhenSourceAndTtlMatches(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", TtlInSec: 60}
+	recToDelete := libdns.RR{Name: "sub1", TTL: time.Duration(60 * time.Second)}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 1 {
+		t.Fatalf("Expected record to be deleted, but it wasn't")
+	}
+}
+
+func Test_DeleteRecords_DoesNotDeleteRecordIfTtlIsNotMatching(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", TtlInSec: 60}
+	recToDelete := libdns.RR{Name: "sub1", TTL: time.Duration(61)}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 0 {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_DeleteRecords_DeletesRecordWhenSourceAndTypeMatches(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Type: "TXT"}
+	recToDelete := libdns.RR{Name: "sub1", Type: "TXT"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 1 {
+		t.Fatalf("Expected record to be deleted, but it wasn't")
+	}
+}
+
+func Test_DeleteRecords_DoesNotDeleteRecordWhenTypeDoesNotMatch(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Type: "TXT"}
+	recToDelete := libdns.RR{Name: "sub1", Type: "TXT-2"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 0 {
+		t.Fatalf("Expected no record to be deleted")
+	}
+}
+
+func Test_DeleteRecords_DeletesRecordWhenSourceAndTarget(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Target: "127.0.0.1"}
+	recToDelete := libdns.RR{Name: "sub1", Data: "127.0.0.1"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 1 {
+		t.Fatalf("Expected record to be deleted, but it wasn't")
+	}
+}
+
+func Test_DeleteRecords_DoesNotDeleteRecordIfTargetDoesNotMatch(t *testing.T) {
+	existingRec := IkRecord{Source: "sub1", Target: "127.0.0.1"}
+	recToDelete := libdns.RR{Name: "sub1", Data: "127.0.0.2"}
+
+	client := TestClient{
+		zoneGetter: func(ctx context.Context, argZone string) (string, error) { return argZone, nil },
+		getter:     func(ctx context.Context, argZone string) ([]IkRecord, error) { return []IkRecord{existingRec}, nil },
+		deleter:    func(ctx context.Context, argZone, id string) error { return nil },
+	}
+	provider := Provider{client: &client}
+
+	res, _ := provider.DeleteRecords(context.TODO(), "example.com", []libdns.Record{recToDelete})
+
+	if len(res) != 0 {
+		t.Fatalf("Expected no record to be deleted")
 	}
 }

--- a/testing/integration_test.go
+++ b/testing/integration_test.go
@@ -91,7 +91,7 @@ func getRecords(t *testing.T, zone string) []libdns.Record {
 // aTestRecord returns a record that can be used for testing purposes
 func aTestRecord(name string, value string) libdns.Record {
 	return libdns.Record{
-		Type:     "MX",
+		Type:     "A",
 		Name:     libdns.RelativeName(name, zone),
 		Value:    value,
 		TTL:      3600,
@@ -203,6 +203,7 @@ func Test_SetRecords_UpdatesRecordById(t *testing.T) {
 	defer cleanup()
 
 	recToUpdate := aTestRecord(zone, "127.0.0.1")
+	recToUpdate.Type = "TXT"
 	recToUpdate = setRecord(t, recToUpdate)[0]
 
 	updatedRec := recToUpdate
@@ -236,6 +237,7 @@ func Test_SetRecords_OverwritesExistingRecordWithSameNameAndType(t *testing.T) {
 	defer cleanup()
 
 	recToUpdate := aTestRecord(zone, "127.0.0.1")
+	recToUpdate.Type = "TXT"
 	recToUpdate = setRecord(t, recToUpdate)[0]
 
 	updatedRec := recToUpdate

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ import (
 // IkRecord infomaniak API record return type
 type IkRecord struct {
 	// ID of this record on infomaniak's side
-	ID string `json:"id,omitempty"`
+	ID int `json:"id,omitempty"`
 
 	// Type of this record
 	Type string `json:"type"`
@@ -16,18 +16,11 @@ type IkRecord struct {
 	// Absolute Source / Name
 	Source string `json:"source,omitempty"`
 
-	// Source / Name relative to domain name
-	SourceIdn string `json:"source_idn,omitempty"`
-
 	// Value of this record
 	Target string `json:"target"`
 
 	// TTL in seconds
-	TtlInSec uint `json:"ttl"`
-
-	// Priority of this record - default value on infomaniak's side
-	// for records that do not have a priority is 10
-	Priority uint `json:"priority,omitempty"`
+	TtlInSec int `json:"ttl"`
 }
 
 // IkResponse infomaniak API response
@@ -42,13 +35,10 @@ type IkResponse struct {
 	Error json.RawMessage `json:"error,omitempty"`
 }
 
-// IkDomain infomaniak API domain return type
-type IkDomain struct {
-	// Domain's ID on infomaniak's side
-	ID int `json:"id"`
-
-	// Domain name
-	Name string `json:"customer_name"`
+// IkZone infomaniak API zone return type
+type IkZone struct {
+	// Zone's FQDN on infomaniak's side
+	Fqdn string `json:"fqdn"`
 }
 
 // IkClient interface to abstract infomaniak client

--- a/types.go
+++ b/types.go
@@ -11,16 +11,53 @@ type IkRecord struct {
 	ID int `json:"id,omitempty"`
 
 	// Type of this record
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 
 	// Absolute Source / Name
 	Source string `json:"source,omitempty"`
 
 	// Value of this record
-	Target string `json:"target"`
+	Target string `json:"target,omitempty"`
 
 	// TTL in seconds
-	TtlInSec int `json:"ttl"`
+	TtlInSec int `json:"ttl,omitempty"`
+
+	// Record Description
+	Description IkRecordDescription `json:"description,omitempty"`
+}
+
+type IkRecordDescription struct {
+	// Only available for SRV and MX records
+	Priority IkIntValueAttribute `json:"priority,omitempty"`
+
+	// Only available for SRV records
+	Port IkIntValueAttribute `json:"port,omitempty"`
+
+	// Only available for SRV records
+	Weight IkIntValueAttribute `json:"weight,omitempty"`
+
+	// Only available for SRV and DNSKEY records
+	Protocol IkStringValueAttribute `json:"protocol,omitempty"`
+
+	// Only available for CAA and DNSKEY records
+	Flags IkIntValueAttribute `json:"flags,omitempty"`
+
+	// Only available for CAA records
+	Tag IkStringValueAttribute `json:"tag,omitempty"`
+}
+
+type IkIntValueAttribute struct {
+	// Attribute value
+	Value int `json:"value,omitempty"`
+	// Human readable value of attribute
+	Label string `json:"label,omitempty"`
+}
+
+type IkStringValueAttribute struct {
+	// Attribute value
+	Value string `json:"value,omitempty"`
+	// Human readable value of attribute
+	Label string `json:"label,omitempty"`
 }
 
 // IkResponse infomaniak API response
@@ -41,6 +78,16 @@ type IkZone struct {
 	Fqdn string `json:"fqdn"`
 }
 
+// ZoneMapping represents input zone coming from the caller and the zone
+// that is actually managed by infomaniak
+type ZoneMapping struct {
+	// Zone that is mangaged by infomaniak
+	InfomaniakManagedZone string `json:"fqdn"`
+
+	// Zone that is provided by libdns
+	LibDnsZone string
+}
+
 // IkClient interface to abstract infomaniak client
 type IkClient interface {
 	// DeleteRecord deletes record with given ID
@@ -51,4 +98,7 @@ type IkClient interface {
 
 	// GetDnsRecordsForZone returns all records of the given zone
 	GetDnsRecordsForZone(ctx context.Context, zone string) ([]IkRecord, error)
+
+	// GetFqdnOfZoneForDomain returns the FQDN of the zone managed by infomaniak
+	GetFqdnOfZoneForDomain(ctx context.Context, domain string) (string, error)
 }


### PR DESCRIPTION
- Upgrade to libdns v1.0.0-beta: fixes #7 
- Use API v2 published by infomaniak as it is officially documented and provides information required for libdns upgrade: fixes #8 
- Reduce number of integration tests and add more unit tests instead
- Add dev container for faster setup and testing with caddy
- Update readme